### PR TITLE
[Step2] - 수킴

### DIFF
--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		768952C62669E14B00AE4B6F /* CloudNoteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768952C52669E14B00AE4B6F /* CloudNoteError.swift */; };
+		768EDB472670ED1800D8EF18 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768EDB462670ED1800D8EF18 /* DataManager.swift */; };
 		76A5A3C22668951000B21DF8 /* MemoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A5A3C12668951000B21DF8 /* MemoListViewController.swift */; };
 		76A5A3C42668954C00B21DF8 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A5A3C32668954C00B21DF8 /* DetailViewController.swift */; };
 		76A5A3CE2669003C00B21DF8 /* MemoSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A5A3CD2669003C00B21DF8 /* MemoSplitViewController.swift */; };
@@ -42,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		768952C52669E14B00AE4B6F /* CloudNoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudNoteError.swift; sourceTree = "<group>"; };
+		768EDB462670ED1800D8EF18 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		76A5A3C12668951000B21DF8 /* MemoListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoListViewController.swift; sourceTree = "<group>"; };
 		76A5A3C32668954C00B21DF8 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		76A5A3CD2669003C00B21DF8 /* MemoSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSplitViewController.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				76E894062664F700006ED838 /* MemoData.swift */,
+				768EDB462670ED1800D8EF18 /* DataManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 				C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */,
 				C7481C7025BBCF3900B9CA55 /* SceneDelegate.swift in Sources */,
 				76A5A3D426690AAE00B21DF8 /* SendDataDelegate.swift in Sources */,
+				768EDB472670ED1800D8EF18 /* DataManager.swift in Sources */,
 				C7481C7825BBCF3900B9CA55 /* CloudNotes.xcdatamodeld in Sources */,
 				76A5A3C42668954C00B21DF8 /* DetailViewController.swift in Sources */,
 			);

--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		76A5A3CE2669003C00B21DF8 /* MemoSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A5A3CD2669003C00B21DF8 /* MemoSplitViewController.swift */; };
 		76A5A3D0266904CB00B21DF8 /* MemoListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A5A3CF266904CB00B21DF8 /* MemoListCell.swift */; };
 		76A5A3D426690AAE00B21DF8 /* SendDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A5A3D326690AAE00B21DF8 /* SendDataDelegate.swift */; };
+		76AC77F9267B11A000EF3243 /* Memo+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AC77F7267B11A000EF3243 /* Memo+CoreDataClass.swift */; };
+		76AC77FA267B11A000EF3243 /* Memo+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AC77F8267B11A000EF3243 /* Memo+CoreDataProperties.swift */; };
 		76E894072664F700006ED838 /* MemoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E894062664F700006ED838 /* MemoData.swift */; };
 		C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7481C6D25BBCF3900B9CA55 /* AppDelegate.swift */; };
 		C7481C7025BBCF3900B9CA55 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7481C6F25BBCF3900B9CA55 /* SceneDelegate.swift */; };
@@ -49,6 +51,8 @@
 		76A5A3CD2669003C00B21DF8 /* MemoSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSplitViewController.swift; sourceTree = "<group>"; };
 		76A5A3CF266904CB00B21DF8 /* MemoListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoListCell.swift; sourceTree = "<group>"; };
 		76A5A3D326690AAE00B21DF8 /* SendDataDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendDataDelegate.swift; sourceTree = "<group>"; };
+		76AC77F7267B11A000EF3243 /* Memo+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Memo+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
+		76AC77F8267B11A000EF3243 /* Memo+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Memo+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
 		76E894062664F700006ED838 /* MemoData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoData.swift; sourceTree = "<group>"; };
 		C7481C6A25BBCF3900B9CA55 /* CloudNotes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CloudNotes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7481C6D25BBCF3900B9CA55 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -136,6 +140,8 @@
 		C7481C6125BBCF3900B9CA55 = {
 			isa = PBXGroup;
 			children = (
+				76AC77F7267B11A000EF3243 /* Memo+CoreDataClass.swift */,
+				76AC77F8267B11A000EF3243 /* Memo+CoreDataProperties.swift */,
 				C7481C6C25BBCF3900B9CA55 /* CloudNotes */,
 				C7481C8625BBCF3A00B9CA55 /* CloudNotesTests */,
 				C7481C9125BBCF3A00B9CA55 /* CloudNotesUITests */,
@@ -321,12 +327,14 @@
 				76A5A3D0266904CB00B21DF8 /* MemoListCell.swift in Sources */,
 				76A5A3CE2669003C00B21DF8 /* MemoSplitViewController.swift in Sources */,
 				768952C62669E14B00AE4B6F /* CloudNoteError.swift in Sources */,
+				76AC77FA267B11A000EF3243 /* Memo+CoreDataProperties.swift in Sources */,
 				76E894072664F700006ED838 /* MemoData.swift in Sources */,
 				76A5A3C22668951000B21DF8 /* MemoListViewController.swift in Sources */,
 				C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */,
 				C7481C7025BBCF3900B9CA55 /* SceneDelegate.swift in Sources */,
 				76A5A3D426690AAE00B21DF8 /* SendDataDelegate.swift in Sources */,
 				768EDB472670ED1800D8EF18 /* DataManager.swift in Sources */,
+				76AC77F9267B11A000EF3243 /* Memo+CoreDataClass.swift in Sources */,
 				C7481C7825BBCF3900B9CA55 /* CloudNotes.xcdatamodeld in Sources */,
 				76A5A3C42668954C00B21DF8 /* DetailViewController.swift in Sources */,
 			);

--- a/CloudNotes/CloudNotes/AppDelegate.swift
+++ b/CloudNotes/CloudNotes/AppDelegate.swift
@@ -23,6 +23,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
     }
 
-
-
 }

--- a/CloudNotes/CloudNotes/AppDelegate.swift
+++ b/CloudNotes/CloudNotes/AppDelegate.swift
@@ -23,30 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
     }
 
-    // MARK: - Core Data stack
 
-    lazy var persistentContainer: NSPersistentCloudKitContainer = {
-        let container = NSPersistentCloudKitContainer(name: "CloudNotes")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
 
 }

--- a/CloudNotes/CloudNotes/CloudNotes.xcdatamodeld/CloudNotes.xcdatamodel/contents
+++ b/CloudNotes/CloudNotes/CloudNotes.xcdatamodeld/CloudNotes.xcdatamodel/contents
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="true" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Memo" representedClassName="Memo" syncable="YES" codeGenerationType="class">
+        <attribute name="body" optional="YES" attributeType="String"/>
+        <attribute name="lastModifiedDate" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="Memo" positionX="-63" positionY="-18" width="128" height="74"/>
+    </elements>
 </model>

--- a/CloudNotes/CloudNotes/CloudNotes.xcdatamodeld/CloudNotes.xcdatamodel/contents
+++ b/CloudNotes/CloudNotes/CloudNotes.xcdatamodeld/CloudNotes.xcdatamodel/contents
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
-    <entity name="Memo" representedClassName="Memo" syncable="YES" codeGenerationType="class">
+    <entity name="Memo" representedClassName="Memo" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String"/>
-        <attribute name="lastModifiedDate" optional="YES" attributeType="String"/>
+        <attribute name="lastModifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="title" optional="YES" attributeType="String"/>
     </entity>
     <elements>

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -8,12 +8,11 @@
 import UIKit
 
 class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresentationControllerDelegate {
-    
+
     var memoDetailTextView: UITextView = {
         let view = UITextView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.textColor = UIColor.black
-        view.text = "내용을 입력하세요"
         view.textContainerInset = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
         return view
     }()
@@ -22,11 +21,31 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.memoDetailTextView.delegate = self
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(editMemo))
         self.view.addSubview(memoDetailTextView)
         setTextViewConstraint()
+        
+    }
+    
+    func setRegular(first: String, last: String) {
+        let font = UIFont.italicSystemFont(ofSize: 10)
+        let font2 = UIFont.boldSystemFont(ofSize: 20)
+        let fullText = memoDetailTextView.text!
+        
+
+        let attributedString = NSMutableAttributedString(string: fullText)
+        
+        let range = (fullText as NSString).range(of: first)
+        attributedString.addAttribute(.font, value: font2, range: range)
+        
+        if first != last {
+            let range2 = (fullText as NSString).range(of: last)
+            attributedString.addAttribute(.font, value: font, range: range2)
+        }
+
+        memoDetailTextView.attributedText = attributedString
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -34,12 +53,20 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
     }
     
     @objc func editMemo() {
-        detailActionSheet(self.navigationItem.rightBarButtonItem!)
+        guard let editButton = self.navigationItem.rightBarButtonItem else { return }
+        detailActionSheet(editButton)
     }
     
     func sendData(data: Memo, index: Int) {
-        self.memoDetailTextView.text = "\(data.title!)\n\n" + "\(data.body!)"
+        if data.title == "새로운 메모" && data.body == "추가 텍스트 없음" {
+            data.title = ""
+            data.body = ""
+        }
+        self.memoDetailTextView.text = "\(data.title!)\n" + "\(data.body!)"
         self.currentIndex = index
+        if data.title != "" && data.body != "" {
+            setRegular(first: data.title!, last: data.body!)
+        }
     }
     
     func isRegularTextViewColor(regular: Bool) {
@@ -72,15 +99,10 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
 extension DetailViewController: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
+        
         guard let greeting = self.memoDetailTextView.text else { return }
-        let splitText = greeting.split(separator: "\n",maxSplits: 1).map { (value) -> String in
-            return String(value) }
-
-
-        DataManager.shared.memoList[currentIndex].title = splitText.first!
-        DataManager.shared.memoList[currentIndex].body = splitText.last!
-        DataManager.shared.saveContext()
-        DataManager.shared.fetchData()
+        
+        NotificationCenter.default.post(name: NSNotification.Name("didRecieveNotification"), object: nil, userInfo: ["textViewText": greeting, "currentIndex": currentIndex] )
     }
     
 }
@@ -88,46 +110,42 @@ extension DetailViewController: UITextViewDelegate {
 extension DetailViewController {
     
     func deleteAlert() {
-        let defaultAction = UIAlertAction(title: "삭제",
-                                          style: .destructive) { (action) in
+        let defaultAction = UIAlertAction(title: "삭제", style: .destructive) { (action) in
+            DataManager.shared.deleteData(index: self.currentIndex)
+            NotificationCenter.default.post(name: NSNotification.Name("didRecieveNotification"), object: nil, userInfo: nil )
+            if self.splitViewController?.traitCollection.horizontalSizeClass == .compact {
+                self.splitViewController?.show(.primary)
+            }
+            else {
+                self.sendData(data: DataManager.shared.memoList[self.currentIndex], index: self.currentIndex)
+            }
         }
-        let cancelAction = UIAlertAction(title: "취소",
-                                         style: .cancel) { (action) in
-        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         
-        let alert = UIAlertController(title: "진짜요?",
-              message: "정말로 삭제하시겠어요?",
-              preferredStyle: .alert)
+        let alert = UIAlertController(title: "진짜요?", message: "정말로 삭제하시겠어요?", preferredStyle: .alert)
         alert.addAction(defaultAction)
         alert.addAction(cancelAction)
         
-        self.present(alert, animated: true, completion: nil)
+        self.present(alert, animated: true)
     }
     
     func detailActionSheet(_ sender: UIBarButtonItem) {
-        let destroyAction = UIAlertAction(title: "Delete",
-                  style: .destructive) { (action) in
+        let destroyAction = UIAlertAction(title: "Delete", style: .destructive) { (action) in
             self.deleteAlert()
         }
-        let cancelAction = UIAlertAction(title: "Cancel",
-                  style: .cancel) { (action) in
-        }
-        let shareAction = UIAlertAction(title: "Share..",
-                    style: .default) { (action) in
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        let shareAction = UIAlertAction(title: "Share..", style: .default) { (action) in
             self.presentShareSheet(sender)
         }
              
-        let alert = UIAlertController(title: nil,
-                    message: nil,
-                    preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alert.addAction(shareAction)
         alert.addAction(destroyAction)
         alert.addAction(cancelAction)
         
         if let popOverController = alert.popoverPresentationController { popOverController.barButtonItem = sender }
         
-        self.present(alert, animated: true, completion: nil)
-    
+        self.present(alert, animated: true)
     }
     
     func presentShareSheet(_ sender: UIBarButtonItem) {
@@ -137,7 +155,7 @@ extension DetailViewController {
     
         if let popOverController = shareSheetViewController.popoverPresentationController { popOverController.barButtonItem = sender }
         
-        present(shareSheetViewController, animated: true, completion: nil)
+        present(shareSheetViewController, animated: true)
     }
     
 }

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -18,9 +18,12 @@ class DetailViewController: UIViewController, SendDataDelegate {
         return view
     }()
     
+    var currentIndex: Int = 0
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.memoDetailTextView.delegate = self
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(editMemo))
         self.view.addSubview(memoDetailTextView)
         setTextViewConstraint()
@@ -33,8 +36,9 @@ class DetailViewController: UIViewController, SendDataDelegate {
     @objc func editMemo() {
     }
     
-    func sendData(data: Memo) {
-        self.memoDetailTextView.text = "\(data.title)\n\n" + "\(data.body)"
+    func sendData(data: Memo, index: Int) {
+        self.memoDetailTextView.text = "\(data.title!)\n\n" + "\(data.body!)"
+        self.currentIndex = index
     }
     
     func isRegularTextViewColor(regular: Bool) {
@@ -60,6 +64,22 @@ class DetailViewController: UIViewController, SendDataDelegate {
         self.memoDetailTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 0).isActive = true
         self.memoDetailTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: 0).isActive = true
         self.memoDetailTextView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0).isActive = true
+    }
+    
+}
+
+extension DetailViewController: UITextViewDelegate {
+    
+    func textViewDidChange(_ textView: UITextView) {
+        guard let greeting = self.memoDetailTextView.text else { return }
+        let splitText = greeting.split(separator: "\n",maxSplits: 1).map { (value) -> String in
+            return String(value) }
+
+
+        DataManager.shared.memoList[currentIndex].title = splitText.first!
+        DataManager.shared.memoList[currentIndex].body = splitText.last!
+        DataManager.shared.saveContext()
+        DataManager.shared.fetchData()
     }
     
 }

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -24,7 +24,6 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
         super.viewDidLoad()
         
         self.memoDetailTextView.delegate = self
-        self.modalPresentationStyle = .popover
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(editMemo))
         self.view.addSubview(memoDetailTextView)
         setTextViewConstraint()
@@ -68,7 +67,27 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
         self.memoDetailTextView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0).isActive = true
     }
     
-    func deleteAlert(_ sender: UIBarButtonItem) {
+}
+
+extension DetailViewController: UITextViewDelegate {
+    
+    func textViewDidChange(_ textView: UITextView) {
+        guard let greeting = self.memoDetailTextView.text else { return }
+        let splitText = greeting.split(separator: "\n",maxSplits: 1).map { (value) -> String in
+            return String(value) }
+
+
+        DataManager.shared.memoList[currentIndex].title = splitText.first!
+        DataManager.shared.memoList[currentIndex].body = splitText.last!
+        DataManager.shared.saveContext()
+        DataManager.shared.fetchData()
+    }
+    
+}
+
+extension DetailViewController {
+    
+    func deleteAlert() {
         let defaultAction = UIAlertAction(title: "삭제",
                                           style: .destructive) { (action) in
         }
@@ -81,8 +100,6 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
               preferredStyle: .alert)
         alert.addAction(defaultAction)
         alert.addAction(cancelAction)
-        guard let popOverController = alert.popoverPresentationController else { return }
-        popOverController.barButtonItem = sender
         
         self.present(alert, animated: true, completion: nil)
     }
@@ -90,7 +107,7 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
     func detailActionSheet(_ sender: UIBarButtonItem) {
         let destroyAction = UIAlertAction(title: "Delete",
                   style: .destructive) { (action) in
-            self.deleteAlert(sender)
+            self.deleteAlert()
         }
         let cancelAction = UIAlertAction(title: "Cancel",
                   style: .cancel) { (action) in
@@ -107,8 +124,7 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
         alert.addAction(destroyAction)
         alert.addAction(cancelAction)
         
-        guard let popOverController = alert.popoverPresentationController else { return }
-        popOverController.barButtonItem = sender
+        if let popOverController = alert.popoverPresentationController { popOverController.barButtonItem = sender }
         
         self.present(alert, animated: true, completion: nil)
     
@@ -119,26 +135,9 @@ class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresent
         
         let shareSheetViewController = UIActivityViewController(activityItems: [sendText], applicationActivities: nil)
     
-        guard let popOverController = shareSheetViewController.popoverPresentationController else { return }
-        popOverController.barButtonItem = sender
+        if let popOverController = shareSheetViewController.popoverPresentationController { popOverController.barButtonItem = sender }
         
         present(shareSheetViewController, animated: true, completion: nil)
-    }
-    
-}
-
-extension DetailViewController: UITextViewDelegate {
-    
-    func textViewDidChange(_ textView: UITextView) {
-        guard let greeting = self.memoDetailTextView.text else { return }
-        let splitText = greeting.split(separator: "\n",maxSplits: 1).map { (value) -> String in
-            return String(value) }
-
-
-        DataManager.shared.memoList[currentIndex].title = splitText.first!
-        DataManager.shared.memoList[currentIndex].body = splitText.last!
-        DataManager.shared.saveContext()
-        DataManager.shared.fetchData()
     }
     
 }

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DetailViewController: UIViewController, SendDataDelegate {
+class DetailViewController: UIViewController, SendDataDelegate, UIPopoverPresentationControllerDelegate {
     
     var memoDetailTextView: UITextView = {
         let view = UITextView()
@@ -24,6 +24,7 @@ class DetailViewController: UIViewController, SendDataDelegate {
         super.viewDidLoad()
         
         self.memoDetailTextView.delegate = self
+        self.modalPresentationStyle = .popover
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(editMemo))
         self.view.addSubview(memoDetailTextView)
         setTextViewConstraint()
@@ -34,7 +35,7 @@ class DetailViewController: UIViewController, SendDataDelegate {
     }
     
     @objc func editMemo() {
-        detailActionSheet()
+        detailActionSheet(self.navigationItem.rightBarButtonItem!)
     }
     
     func sendData(data: Memo, index: Int) {
@@ -67,7 +68,7 @@ class DetailViewController: UIViewController, SendDataDelegate {
         self.memoDetailTextView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0).isActive = true
     }
     
-    func deleteAlert() {
+    func deleteAlert(_ sender: UIBarButtonItem) {
         let defaultAction = UIAlertAction(title: "삭제",
                                           style: .destructive) { (action) in
         }
@@ -80,20 +81,23 @@ class DetailViewController: UIViewController, SendDataDelegate {
               preferredStyle: .alert)
         alert.addAction(defaultAction)
         alert.addAction(cancelAction)
-             
+        guard let popOverController = alert.popoverPresentationController else { return }
+        popOverController.barButtonItem = sender
+        
         self.present(alert, animated: true, completion: nil)
     }
     
-    func detailActionSheet() {
+    func detailActionSheet(_ sender: UIBarButtonItem) {
         let destroyAction = UIAlertAction(title: "Delete",
                   style: .destructive) { (action) in
+            self.deleteAlert(sender)
         }
         let cancelAction = UIAlertAction(title: "Cancel",
                   style: .cancel) { (action) in
         }
         let shareAction = UIAlertAction(title: "Share..",
                     style: .default) { (action) in
-            
+            self.presentShareSheet(sender)
         }
              
         let alert = UIAlertController(title: nil,
@@ -103,7 +107,22 @@ class DetailViewController: UIViewController, SendDataDelegate {
         alert.addAction(destroyAction)
         alert.addAction(cancelAction)
         
+        guard let popOverController = alert.popoverPresentationController else { return }
+        popOverController.barButtonItem = sender
+        
         self.present(alert, animated: true, completion: nil)
+    
+    }
+    
+    func presentShareSheet(_ sender: UIBarButtonItem) {
+        guard let sendText = self.memoDetailTextView.text else { return }
+        
+        let shareSheetViewController = UIActivityViewController(activityItems: [sendText], applicationActivities: nil)
+    
+        guard let popOverController = shareSheetViewController.popoverPresentationController else { return }
+        popOverController.barButtonItem = sender
+        
+        present(shareSheetViewController, animated: true, completion: nil)
     }
     
 }

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -66,6 +66,23 @@ class DetailViewController: UIViewController, SendDataDelegate {
         self.memoDetailTextView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0).isActive = true
     }
     
+    func deleteAlert() {
+        let defaultAction = UIAlertAction(title: "삭제",
+                                          style: .destructive) { (action) in
+        }
+        let cancelAction = UIAlertAction(title: "취소",
+                                         style: .cancel) { (action) in
+        }
+        
+        let alert = UIAlertController(title: "진짜요?",
+              message: "정말로 삭제하시겠어요?",
+              preferredStyle: .alert)
+        alert.addAction(defaultAction)
+        alert.addAction(cancelAction)
+             
+        self.present(alert, animated: true, completion: nil)
+    }
+    
 }
 
 extension DetailViewController: UITextViewDelegate {

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -33,7 +33,7 @@ class DetailViewController: UIViewController, SendDataDelegate {
     @objc func editMemo() {
     }
     
-    func sendData(data: MemoData) {
+    func sendData(data: Memo) {
         self.memoDetailTextView.text = "\(data.title)\n\n" + "\(data.body)"
     }
     

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -34,6 +34,7 @@ class DetailViewController: UIViewController, SendDataDelegate {
     }
     
     @objc func editMemo() {
+        detailActionSheet()
     }
     
     func sendData(data: Memo, index: Int) {
@@ -80,6 +81,28 @@ class DetailViewController: UIViewController, SendDataDelegate {
         alert.addAction(defaultAction)
         alert.addAction(cancelAction)
              
+        self.present(alert, animated: true, completion: nil)
+    }
+    
+    func detailActionSheet() {
+        let destroyAction = UIAlertAction(title: "Delete",
+                  style: .destructive) { (action) in
+        }
+        let cancelAction = UIAlertAction(title: "Cancel",
+                  style: .cancel) { (action) in
+        }
+        let shareAction = UIAlertAction(title: "Share..",
+                    style: .default) { (action) in
+            
+        }
+             
+        let alert = UIAlertController(title: nil,
+                    message: nil,
+                    preferredStyle: .actionSheet)
+        alert.addAction(shareAction)
+        alert.addAction(destroyAction)
+        alert.addAction(cancelAction)
+        
         self.present(alert, animated: true, completion: nil)
     }
     

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -98,7 +98,6 @@ class DetailViewController: UIViewController, SendDataDelegate {
 extension DetailViewController: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
-        
         guard let greeting = self.memoDetailTextView.text else { return }
         
         NotificationCenter.default.post(name: NSNotification.Name("didRecieveNotification"), object: nil, userInfo: ["textViewText": greeting, "currentIndex": currentIndex] )

--- a/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
@@ -43,6 +43,8 @@ class MemoListViewController: UIViewController {
         newMemo.lastModifiedDate = "날짜"
         
         DataManager.shared.saveContext()
+        DataManager.shared.fetchData()
+        self.memoTableView.reloadData()
     }
     
     private func setTableViewConstraint() {
@@ -91,6 +93,18 @@ extension MemoListViewController: UITableViewDelegate {
         if UITraitCollection.current.horizontalSizeClass == .compact {
             splitViewController?.showDetailViewController(UINavigationController(rootViewController: memoDetailViewController) , sender: nil)
         }
+    }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let action = UIContextualAction(style: .destructive, title: "Delete") { (action, view, completionHandler ) in
+            let memoToRemove = DataManager.shared.memoList[indexPath.row]
+            DataManager.shared.mainContext.delete(memoToRemove)
+            DataManager.shared.saveContext()
+            DataManager.shared.fetchData()
+            self.memoTableView.reloadData()
+        }
+        
+        return UISwipeActionsConfiguration(actions: [action])
     }
     
 }

--- a/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
@@ -86,7 +86,8 @@ class MemoListViewController: UIViewController {
 extension MemoListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        delegate?.sendData(data: DataManager.shared.memoList[indexPath.row])
+        self.memoTableView.reloadData()
+        delegate?.sendData(data: DataManager.shared.memoList[indexPath.row], index: indexPath.row)
         
         guard let memoDetailViewController = delegate as? DetailViewController else { return }
         

--- a/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
@@ -107,7 +107,7 @@ extension MemoListViewController: UITableViewDelegate {
         }
         
         let shareAction = UIContextualAction(style: .normal, title: "공유") { (action, view, completionHandler ) in
-            guard let sendText = DataManager.shared.memoList[indexPath.row].body else { return }
+            let sendText = DataManager.shared.memoList[indexPath.row].body
             
             let shareSheetViewController = UIActivityViewController(activityItems: [sendText], applicationActivities: nil)
         

--- a/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MemoListViewController.swift
@@ -30,10 +30,19 @@ class MemoListViewController: UIViewController {
         if splitViewController?.traitCollection.horizontalSizeClass == .regular {
             delegate?.isRegularTextViewColor(regular: true)
         }
+        
+        DataManager.shared.fetchData()
+        self.memoTableView.reloadData()
     }
     
     @objc func addNote() {
+        let newMemo = Memo(context: DataManager.shared.mainContext)
         
+        newMemo.title = "새메모"
+        newMemo.body = "새바디"
+        newMemo.lastModifiedDate = "날짜"
+        
+        DataManager.shared.saveContext()
     }
     
     private func setTableViewConstraint() {
@@ -75,7 +84,7 @@ class MemoListViewController: UIViewController {
 extension MemoListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        delegate?.sendData(data: memoData[indexPath.row])
+        delegate?.sendData(data: DataManager.shared.memoList[indexPath.row])
         
         guard let memoDetailViewController = delegate as? DetailViewController else { return }
         
@@ -89,12 +98,12 @@ extension MemoListViewController: UITableViewDelegate {
 extension MemoListViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return memoData.count
+        return DataManager.shared.memoList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: MemoListCell.identifier, for: indexPath) as! MemoListCell
-        let currentMemoData = memoData[indexPath.row]
+        let currentMemoData = DataManager.shared.memoList[indexPath.row]
         
         cell.setCellData(currentMemoData: currentMemoData)
 

--- a/CloudNotes/CloudNotes/Controller/MemoSplitViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MemoSplitViewController.swift
@@ -16,20 +16,19 @@ class MemoSplitViewController: UISplitViewController, UISplitViewControllerDeleg
         setSplitView()
     }
     
-    private func setSplitView() {
+    func setSplitView() {
         let memoListViewController = MemoListViewController()
         let detailViewController = DetailViewController()
         memoListViewController.title = "메모"
         memoListViewController.delegate = detailViewController
-    
-        let memoListViewNavigationController = UINavigationController(rootViewController: memoListViewController)
-        let detailViewNavigationController = UINavigationController(rootViewController: detailViewController)
         self.preferredDisplayMode = .oneBesideSecondary
-        self.viewControllers = [memoListViewNavigationController, detailViewNavigationController]
+        self.setViewController(memoListViewController, for: .primary)
+        self.setViewController(detailViewController, for: .secondary)
+        self.preferredSplitBehavior = .tile
     }
-
-    func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController) -> Bool {
-        return true
+    
+    func splitViewController(_ svc: UISplitViewController, topColumnForCollapsingToProposedTopColumn proposedTopColumn: UISplitViewController.Column) -> UISplitViewController.Column {
+        return .primary
     }
     
 }

--- a/CloudNotes/CloudNotes/Model/DataManager.swift
+++ b/CloudNotes/CloudNotes/Model/DataManager.swift
@@ -29,12 +29,10 @@ class DataManager {
     
     func createData() {
         let newMemo = Memo(context: mainContext)
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy. MM. dd."
 
         newMemo.title = "새로운 메모"
         newMemo.body = "추가 텍스트 없음"
-        newMemo.lastModifiedDate = formatter.string(from: Date())
+        newMemo.lastModifiedDate = Date()
         
         saveContext()
         fetchData()

--- a/CloudNotes/CloudNotes/Model/DataManager.swift
+++ b/CloudNotes/CloudNotes/Model/DataManager.swift
@@ -27,6 +27,26 @@ class DataManager {
         }
     }
     
+    func createData() {
+        let newMemo = Memo(context: mainContext)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy. MM. dd."
+
+        newMemo.title = "새로운 메모"
+        newMemo.body = "추가 텍스트 없음"
+        newMemo.lastModifiedDate = formatter.string(from: Date())
+        
+        saveContext()
+        fetchData()
+    }
+    
+    func deleteData(index: Int) {
+        let memoToRemove = memoList[index]
+        mainContext.delete(memoToRemove)
+        saveContext()
+        fetchData()
+    }
+    
     // MARK: - Core Data stack
 
     lazy var persistentContainer: NSPersistentCloudKitContainer = {

--- a/CloudNotes/CloudNotes/Model/DataManager.swift
+++ b/CloudNotes/CloudNotes/Model/DataManager.swift
@@ -19,6 +19,7 @@ class DataManager {
     
     func fetchData() {
         let request: NSFetchRequest<Memo> = Memo.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "lastModifiedDate", ascending: false)]
         
         do {
             memoList = try mainContext.fetch(request)

--- a/CloudNotes/CloudNotes/Model/DataManager.swift
+++ b/CloudNotes/CloudNotes/Model/DataManager.swift
@@ -52,4 +52,5 @@ class DataManager {
             }
         }
     }
+    
 }

--- a/CloudNotes/CloudNotes/Model/DataManager.swift
+++ b/CloudNotes/CloudNotes/Model/DataManager.swift
@@ -1,0 +1,55 @@
+//
+//  DataManager.swift
+//  CloudNotes
+//
+//  Created by sookim on 2021/06/09.
+//
+
+import Foundation
+import CoreData
+
+class DataManager {
+    static let shared = DataManager()
+    
+    var mainContext: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    var memoList = [Memo]()
+    
+    func fetchData() {
+        let request: NSFetchRequest<Memo> = Memo.fetchRequest()
+        
+        do {
+            memoList = try mainContext.fetch(request)
+        } catch {
+            print("데이터 불러오기 실패")
+        }
+    }
+    
+    // MARK: - Core Data stack
+
+    lazy var persistentContainer: NSPersistentCloudKitContainer = {
+        let container = NSPersistentCloudKitContainer(name: "CloudNotes")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+}

--- a/CloudNotes/CloudNotes/Protocol/SendDataDelegate.swift
+++ b/CloudNotes/CloudNotes/Protocol/SendDataDelegate.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol SendDataDelegate {
 
-    func sendData(data: Memo)
+    func sendData(data: Memo, index: Int)
     func isRegularTextViewColor(regular: Bool)
     
 }

--- a/CloudNotes/CloudNotes/Protocol/SendDataDelegate.swift
+++ b/CloudNotes/CloudNotes/Protocol/SendDataDelegate.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol SendDataDelegate {
 
-    func sendData(data: MemoData)
+    func sendData(data: Memo)
     func isRegularTextViewColor(regular: Bool)
     
 }

--- a/CloudNotes/CloudNotes/Protocol/SendDataDelegate.swift
+++ b/CloudNotes/CloudNotes/Protocol/SendDataDelegate.swift
@@ -11,5 +11,5 @@ protocol SendDataDelegate {
 
     func sendData(data: Memo, index: Int)
     func isRegularTextViewColor(regular: Bool)
-    
+
 }

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -33,7 +33,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+        DataManager.shared.saveContext()
     }
 
 }

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -12,9 +12,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        window = UIWindow(windowScene: windowScene)
-        let mainViewController = MemoSplitViewController()
         
+        window = UIWindow(windowScene: windowScene)
+        let mainViewController = MemoSplitViewController(style: .doubleColumn)
+
         window?.backgroundColor = .systemBackground
         window?.rootViewController = mainViewController
         window?.makeKeyAndVisible()

--- a/CloudNotes/CloudNotes/View/MemoListCell.swift
+++ b/CloudNotes/CloudNotes/View/MemoListCell.swift
@@ -76,5 +76,4 @@ class MemoListCell: UITableViewCell {
         self.memoDateCreate.text = currentMemoData.lastModifiedDate
         self.accessoryType = .disclosureIndicator
     }
-    
 }

--- a/CloudNotes/CloudNotes/View/MemoListCell.swift
+++ b/CloudNotes/CloudNotes/View/MemoListCell.swift
@@ -42,8 +42,6 @@ class MemoListCell: UITableViewCell {
         self.addSubview(memoDateCreate)
         self.addSubview(memoPreview)
         setCellContentsConstraint()
-
-        self.accessoryType = .disclosureIndicator
     }
 
     
@@ -71,9 +69,12 @@ class MemoListCell: UITableViewCell {
     }
     
     func setCellData(currentMemoData: Memo) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy. MM. dd."
+
         self.memoTitle.text = currentMemoData.title
         self.memoPreview.text = currentMemoData.body
-        self.memoDateCreate.text = currentMemoData.lastModifiedDate
+        self.memoDateCreate.text = formatter.string(from: currentMemoData.lastModifiedDate)
         self.accessoryType = .disclosureIndicator
     }
 }

--- a/CloudNotes/CloudNotes/View/MemoListCell.swift
+++ b/CloudNotes/CloudNotes/View/MemoListCell.swift
@@ -70,7 +70,7 @@ class MemoListCell: UITableViewCell {
         memoPreview.heightAnchor.constraint(equalTo: memoDateCreate.heightAnchor, multiplier: 1).isActive = true
     }
     
-    func setCellData(currentMemoData: MemoData) {
+    func setCellData(currentMemoData: Memo) {
         self.memoTitle.text = currentMemoData.title
         self.memoPreview.text = currentMemoData.body
         self.memoDateCreate.text = currentMemoData.lastModifiedDate

--- a/CloudNotes/CloudNotes/View/MemoListCell.swift
+++ b/CloudNotes/CloudNotes/View/MemoListCell.swift
@@ -75,7 +75,6 @@ class MemoListCell: UITableViewCell {
         self.memoPreview.text = currentMemoData.body
         self.memoDateCreate.text = currentMemoData.lastModifiedDate
         self.accessoryType = .disclosureIndicator
-        self.selectionStyle = .none
     }
     
 }

--- a/CloudNotes/Memo+CoreDataClass.swift
+++ b/CloudNotes/Memo+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Memo+CoreDataClass.swift
+//  CloudNotes
+//
+//  Created by sookim on 2021/06/17.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Memo)
+public class Memo: NSManagedObject {
+
+}

--- a/CloudNotes/Memo+CoreDataProperties.swift
+++ b/CloudNotes/Memo+CoreDataProperties.swift
@@ -1,0 +1,27 @@
+//
+//  Memo+CoreDataProperties.swift
+//  CloudNotes
+//
+//  Created by sookim on 2021/06/17.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Memo {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Memo> {
+        return NSFetchRequest<Memo>(entityName: "Memo")
+    }
+
+    @NSManaged public var body: String
+    @NSManaged public var lastModifiedDate: Date
+    @NSManaged public var title: String
+
+}
+
+extension Memo : Identifiable {
+
+}


### PR DESCRIPTION
@wonhee009 

안녕하세요 라자냐 ㅎㅎ 

step2를 완벽히 끝내지는 않았지만 진행한 부분까지 피드백을 받고 싶어서 PR을 올립니다.😅

 

### Step2 구현한 부분

- CoreData에서 Stack을 만들고 , context에 저장하는 메서드를 `AppDelegate`에서 `DataManger`클래스로 옮겼어요.
- 기존에는 `SplitViewController`를 생성할 때 style을 지정하지 않았는데 `DetailViewController`에서 메모가 삭제되었을 때 화면전환하기 위해서 `dismiss`, `navigationPop` 모두 안되서 `show column` 을 사용하기 위해 style을 doubleColumn으로 지정했어요.
- Alert 부분을 구현하고 아이패드에서는 액션시트와 액티비티뷰가 popOver형식으로 보여줘야 하기 때문에 처리를 해줬어요.
- 코어데이터 모델에서 속성들에 대해서 옵셔널이 아닌 타입으로 정의했어요
- 제목의 폰트는 bold, 본문의 폰트는 italic으로 지정했어요.
- 각 셀의 스와이프 액션을 지정했어요.

---

### 고민한 부분

1. 기존에 사용했지만 현재 사용하지 않는 경우 삭제하는 지 궁금해요 
    - step1에서 테이블뷰의 셀 내용을 JSON파일로 읽어서 사용했기 때문에 `MemoData`클래스가 존재하는데 step2에서는 사용하지 않는 경우처럼
    - 현업에서 추후 사용하지 않을 것 같은 코드들은 삭제를 하고 진행하는 지 궁금해요 😄

2. tableView를 업데이트해주는 `reloadData()`메서드 궁금한 부분
    - `reloadData`는 테이블 뷰 전체를 완전히 처음부터 구성하기 때문에 비용이 많이 든다고 하는데 코드 중에서 필요하지 않은 부분에 사용한 적이 있는 지 라자냐가 지적해주시면 도움이 많이 될 것 같아요 ~

3. 델리게이트 패턴 
    - 델리게이트패턴을 이용해서 `MemoListViewController` → `DetailViewController` 로 화면이 전환될 때 데이터를 넘겨주는 데 DetailViewController에서 TextView의 텍스트가 변경될 때 `NotificationCenter`를 이용해서 다시 데이터를 넘겨주는 방식을 사용했습니다.

        두개의 뷰컨트롤러에서 데이터 전달을 하는 경우 델리게이트패턴과 `NotificationCenter`를 혼용해서 사용해도 되도 문제가 없나요?? 🤔 

    - 델리게이트 패턴을 `DetailViewController`가 프로토콜을 채택하도록 하였는데 반대로 해야되는 지 헷갈렸어요 😅

4. `NSAttributeString`을 이용해서 제목과 본문 스타일을 변경했는데 setTitleBodyFont()라는 메서드를 이용해서 텍스트뷰에서 텍스트뷰에 실시간으로 폰트가 변경되기를 원해서 `textViewDidChange()`에서 사용하면 첫째 줄에 한 번입력될때마다 다음 칸으로 넘어가는 문제가 발생하는 데 무슨 문제인지 파악하는 게 어려웠어요

    > 예시

    ```swift
    func textViewDidChange(_ textView: UITextView) {
            
            guard let greeting = self.memoDetailTextView.text else { return }
            
            let splitText = greeting.split(separator: "\n",maxSplits: 1).map { (value) -> String in
                return String(value) }
            
            DataManager.shared.memoList[currentIndex].title = splitText.first ?? ""
            if splitText.first != splitText.last {
                DataManager.shared.memoList[currentIndex].body = splitText.last ?? ""
            }
            
            setTitleBodyFont(firstSplitText: splitText.first!, lastSplitText: splitText.last!) 
            NotificationCenter.default.post(name: NSNotification.Name("didRecieveNotification"), object: nil, userInfo: ["textViewText": greeting, "currentIndex": currentIndex] )
        }
    ```

    - textViewDidChange()를 예시처럼 코드를 변경하면

        → 텍스트뷰의 두번째줄에서는 실시간으로 폰트가 잘 적용이 되는데 첫번째 줄을 사용하면 한칸 입력시마다 다음칸으로 넘어가는 문제가 발생합니다.