### PR TITLE
동기화 메모장 [STEP3] 호박, 아리

### DIFF
--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9A45A82327BDDF1200CE33DD /* SwiftyDropbox in Frameworks */ = {isa = PBXBuildFile; productRef = 9A45A82227BDDF1200CE33DD /* SwiftyDropbox */; };
 		9A7A1B1627B25FF000639908 /* Collection+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A1B1527B25FF000639908 /* Collection+extension.swift */; };
 		9A7A1B1827B28D3800639908 /* UIViewController+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A1B1727B28D3800639908 /* UIViewController+extension.swift */; };
+		9A8C931327C4702E00545F2F /* DropboxError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8C931227C4702E00545F2F /* DropboxError.swift */; };
 		C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7481C6D25BBCF3900B9CA55 /* AppDelegate.swift */; };
 		C7481C7025BBCF3900B9CA55 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7481C6F25BBCF3900B9CA55 /* SceneDelegate.swift */; };
 		C7481C7225BBCF3900B9CA55 /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7481C7125BBCF3900B9CA55 /* SplitViewController.swift */; };
@@ -67,6 +68,7 @@
 		9A45A7DB27B65B6800CE33DD /* Array+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+extension.swift"; sourceTree = "<group>"; };
 		9A7A1B1527B25FF000639908 /* Collection+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+extension.swift"; sourceTree = "<group>"; };
 		9A7A1B1727B28D3800639908 /* UIViewController+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+extension.swift"; sourceTree = "<group>"; };
+		9A8C931227C4702E00545F2F /* DropboxError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxError.swift; sourceTree = "<group>"; };
 		C7481C6A25BBCF3900B9CA55 /* CloudNotes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CloudNotes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7481C6D25BBCF3900B9CA55 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C7481C6F25BBCF3900B9CA55 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -167,6 +169,14 @@
 			path = Utility;
 			sourceTree = "<group>";
 		};
+		9A8C931527C4704000545F2F /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				9A8C931227C4702E00545F2F /* DropboxError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		C7481C6125BBCF3900B9CA55 = {
 			isa = PBXGroup;
 			children = (
@@ -200,6 +210,7 @@
 				2585783727B2623700889D06 /* Model */,
 				C7481C6D25BBCF3900B9CA55 /* AppDelegate.swift */,
 				C7481C6F25BBCF3900B9CA55 /* SceneDelegate.swift */,
+				9A8C931527C4704000545F2F /* Error */,
 				C7481C7925BBCF3A00B9CA55 /* Assets.xcassets */,
 				C7481C7B25BBCF3A00B9CA55 /* LaunchScreen.storyboard */,
 				C7481C7E25BBCF3A00B9CA55 /* Info.plist */,
@@ -386,6 +397,7 @@
 				256119B627BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift in Sources */,
 				256119B427BCBF0A005B0A07 /* NotesViewControllerDelegate.swift in Sources */,
 				9A7A1B1827B28D3800639908 /* UIViewController+extension.swift in Sources */,
+				9A8C931327C4702E00545F2F /* DropboxError.swift in Sources */,
 				EA2CDF2927B210AB00D8BE65 /* NotesCell.swift in Sources */,
 				2585783627B23F8300889D06 /* TimeInterval+extension.swift in Sources */,
 				2585783027B206EE00889D06 /* NoteDetailViewController.swift in Sources */,

--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		25297A5927C36E770040CD5F /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25297A5827C36E770040CD5F /* AuthenticationViewController.swift */; };
 		256119B427BCBF0A005B0A07 /* NotesViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B327BCBF0A005B0A07 /* NotesViewControllerDelegate.swift */; };
 		256119B627BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B527BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift */; };
 		256119B927BDEFEC005B0A07 /* DropboxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B827BDEFEC005B0A07 /* DropboxManager.swift */; };
@@ -51,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		25297A5827C36E770040CD5F /* AuthenticationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewController.swift; sourceTree = "<group>"; };
 		256119B327BCBF0A005B0A07 /* NotesViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesViewControllerDelegate.swift; sourceTree = "<group>"; };
 		256119B527BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesDetailViewControllerDelegate.swift; sourceTree = "<group>"; };
 		256119B827BDEFEC005B0A07 /* DropboxManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxManager.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				C7481C7125BBCF3900B9CA55 /* SplitViewController.swift */,
 				2585782D27B2060E00889D06 /* NotesViewController.swift */,
 				2585782F27B206EE00889D06 /* NoteDetailViewController.swift */,
+				25297A5827C36E770040CD5F /* AuthenticationViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 				C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */,
 				256119B927BDEFEC005B0A07 /* DropboxManager.swift in Sources */,
 				C7481C7025BBCF3900B9CA55 /* SceneDelegate.swift in Sources */,
+				25297A5927C36E770040CD5F /* AuthenticationViewController.swift in Sources */,
 				2585782E27B2060E00889D06 /* NotesViewController.swift in Sources */,
 				C7481C7825BBCF3900B9CA55 /* CloudNotes.xcdatamodeld in Sources */,
 				2585788027B4D90100889D06 /* Note+CoreDataProperties.swift in Sources */,

--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -18,6 +18,7 @@
 		2585788227B4D98300889D06 /* PersistentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585788127B4D98300889D06 /* PersistentManager.swift */; };
 		258578FF27BA292200889D06 /* UIFont+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258578FE27BA292200889D06 /* UIFont+extension.swift */; };
 		9A45A7DC27B65B6800CE33DD /* Array+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A45A7DB27B65B6800CE33DD /* Array+extension.swift */; };
+		9A45A82327BDDF1200CE33DD /* SwiftyDropbox in Frameworks */ = {isa = PBXBuildFile; productRef = 9A45A82227BDDF1200CE33DD /* SwiftyDropbox */; };
 		9A7A1B1627B25FF000639908 /* Collection+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A1B1527B25FF000639908 /* Collection+extension.swift */; };
 		9A7A1B1827B28D3800639908 /* UIViewController+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A1B1727B28D3800639908 /* UIViewController+extension.swift */; };
 		C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7481C6D25BBCF3900B9CA55 /* AppDelegate.swift */; };
@@ -84,6 +85,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A45A82327BDDF1200CE33DD /* SwiftyDropbox in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -235,6 +237,9 @@
 			dependencies = (
 			);
 			name = CloudNotes;
+			packageProductDependencies = (
+				9A45A82227BDDF1200CE33DD /* SwiftyDropbox */,
+			);
 			productName = CloudNotes;
 			productReference = C7481C6A25BBCF3900B9CA55 /* CloudNotes.app */;
 			productType = "com.apple.product-type.application";
@@ -306,6 +311,9 @@
 				Base,
 			);
 			mainGroup = C7481C6125BBCF3900B9CA55;
+			packageReferences = (
+				9A45A82127BDDF1200CE33DD /* XCRemoteSwiftPackageReference "SwiftyDropbox" */,
+			);
 			productRefGroup = C7481C6B25BBCF3900B9CA55 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -704,6 +712,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9A45A82127BDDF1200CE33DD /* XCRemoteSwiftPackageReference "SwiftyDropbox" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/dropbox/SwiftyDropbox.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9A45A82227BDDF1200CE33DD /* SwiftyDropbox */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9A45A82127BDDF1200CE33DD /* XCRemoteSwiftPackageReference "SwiftyDropbox" */;
+			productName = SwiftyDropbox;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		C7481C7625BBCF3900B9CA55 /* CloudNotes.xcdatamodeld */ = {

--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		256119B427BCBF0A005B0A07 /* NotesViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B327BCBF0A005B0A07 /* NotesViewControllerDelegate.swift */; };
 		256119B627BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B527BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift */; };
-		256119B927BDEFEC005B0A07 /* DropBoxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B827BDEFEC005B0A07 /* DropBoxManager.swift */; };
+		256119B927BDEFEC005B0A07 /* DropboxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B827BDEFEC005B0A07 /* DropboxManager.swift */; };
 		2585782A27B1023000889D06 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585782927B1023000889D06 /* JSONParser.swift */; };
 		2585782E27B2060E00889D06 /* NotesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585782D27B2060E00889D06 /* NotesViewController.swift */; };
 		2585783027B206EE00889D06 /* NoteDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585782F27B206EE00889D06 /* NoteDetailViewController.swift */; };
@@ -53,7 +53,7 @@
 /* Begin PBXFileReference section */
 		256119B327BCBF0A005B0A07 /* NotesViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesViewControllerDelegate.swift; sourceTree = "<group>"; };
 		256119B527BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesDetailViewControllerDelegate.swift; sourceTree = "<group>"; };
-		256119B827BDEFEC005B0A07 /* DropBoxManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropBoxManager.swift; sourceTree = "<group>"; };
+		256119B827BDEFEC005B0A07 /* DropboxManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxManager.swift; sourceTree = "<group>"; };
 		2585782927B1023000889D06 /* JSONParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
 		2585782D27B2060E00889D06 /* NotesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesViewController.swift; sourceTree = "<group>"; };
 		2585782F27B206EE00889D06 /* NoteDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDetailViewController.swift; sourceTree = "<group>"; };
@@ -159,7 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				2585788127B4D98300889D06 /* PersistentManager.swift */,
-				256119B827BDEFEC005B0A07 /* DropBoxManager.swift */,
+				256119B827BDEFEC005B0A07 /* DropboxManager.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -389,7 +389,7 @@
 				2585787F27B4D90100889D06 /* Note+CoreDataClass.swift in Sources */,
 				2585782A27B1023000889D06 /* JSONParser.swift in Sources */,
 				C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */,
-				256119B927BDEFEC005B0A07 /* DropBoxManager.swift in Sources */,
+				256119B927BDEFEC005B0A07 /* DropboxManager.swift in Sources */,
 				C7481C7025BBCF3900B9CA55 /* SceneDelegate.swift in Sources */,
 				2585782E27B2060E00889D06 /* NotesViewController.swift in Sources */,
 				C7481C7825BBCF3900B9CA55 /* CloudNotes.xcdatamodeld in Sources */,

--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		256119B427BCBF0A005B0A07 /* NotesViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B327BCBF0A005B0A07 /* NotesViewControllerDelegate.swift */; };
 		256119B627BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B527BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift */; };
+		256119B927BDEFEC005B0A07 /* DropBoxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256119B827BDEFEC005B0A07 /* DropBoxManager.swift */; };
 		2585782A27B1023000889D06 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585782927B1023000889D06 /* JSONParser.swift */; };
 		2585782E27B2060E00889D06 /* NotesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585782D27B2060E00889D06 /* NotesViewController.swift */; };
 		2585783027B206EE00889D06 /* NoteDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2585782F27B206EE00889D06 /* NoteDetailViewController.swift */; };
@@ -52,6 +53,7 @@
 /* Begin PBXFileReference section */
 		256119B327BCBF0A005B0A07 /* NotesViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesViewControllerDelegate.swift; sourceTree = "<group>"; };
 		256119B527BCBF22005B0A07 /* NotesDetailViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesDetailViewControllerDelegate.swift; sourceTree = "<group>"; };
+		256119B827BDEFEC005B0A07 /* DropBoxManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropBoxManager.swift; sourceTree = "<group>"; };
 		2585782927B1023000889D06 /* JSONParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
 		2585782D27B2060E00889D06 /* NotesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesViewController.swift; sourceTree = "<group>"; };
 		2585782F27B206EE00889D06 /* NoteDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDetailViewController.swift; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				2585788127B4D98300889D06 /* PersistentManager.swift */,
+				256119B827BDEFEC005B0A07 /* DropBoxManager.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -386,6 +389,7 @@
 				2585787F27B4D90100889D06 /* Note+CoreDataClass.swift in Sources */,
 				2585782A27B1023000889D06 /* JSONParser.swift in Sources */,
 				C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */,
+				256119B927BDEFEC005B0A07 /* DropBoxManager.swift in Sources */,
 				C7481C7025BBCF3900B9CA55 /* SceneDelegate.swift in Sources */,
 				2585782E27B2060E00889D06 /* NotesViewController.swift in Sources */,
 				C7481C7825BBCF3900B9CA55 /* CloudNotes.xcdatamodeld in Sources */,

--- a/CloudNotes/CloudNotes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CloudNotes/CloudNotes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
+        "state": {
+          "branch": null,
+          "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e79121864",
+          "version": "5.5.0"
+        }
+      },
+      {
+        "package": "SwiftyDropbox",
+        "repositoryURL": "https://github.com/dropbox/SwiftyDropbox.git",
+        "state": {
+          "branch": null,
+          "revision": "7af87d903be1cf0af0e76e0394d992943055894e",
+          "version": "8.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/CloudNotes/CloudNotes/AppDelegate.swift
+++ b/CloudNotes/CloudNotes/AppDelegate.swift
@@ -6,14 +6,13 @@
 
 import UIKit
 import CoreData
+import SwiftyDropbox
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        DropboxClientsManager.setupWithAppKey("zblgyro9xyhr2xo") // DropboxClient init
         return true
     }
 

--- a/CloudNotes/CloudNotes/Controller/AuthenticationViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/AuthenticationViewController.swift
@@ -1,0 +1,40 @@
+//
+//  AuthenticationViewController.swift
+//  CloudNotes
+//
+//  Created by 박병호 on 2022/02/21.
+//
+
+import UIKit
+
+class AuthenticationViewController: UIViewController {
+
+    let dropBoxManager = DropboxManager()
+    
+    lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView()
+        activityIndicator.center = self.view.center
+        activityIndicator.style = UIActivityIndicatorView.Style.large
+        activityIndicator.startAnimating()
+        activityIndicator.isHidden = false
+        return activityIndicator
+    }()
+    
+    lazy var backgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black
+        view.alpha = 0.3
+        view.frame = self.view.frame
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(backgroundView)
+        view.addSubview(activityIndicator)
+        DispatchQueue.main.async {
+            self.dropBoxManager.authorize(self)
+        }
+    }
+
+}

--- a/CloudNotes/CloudNotes/Controller/NoteDetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/NoteDetailViewController.swift
@@ -70,8 +70,6 @@ extension NoteDetailViewController {
                     section: .zero
                 )
             )
-            self.currentIndex = self.currentIndex - 1 < 0 ? 0 : self.currentIndex - 1
-            self.updateData(with: self.currentIndex)
         }
     }
 }

--- a/CloudNotes/CloudNotes/Controller/NotesViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/NotesViewController.swift
@@ -28,10 +28,6 @@ class NotesViewController: UITableViewController {
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
         tableView.selectRow(at: selectedIndex, animated: false, scrollPosition: .none)
-        if editing == false {
-            delegate?.clearTextView()
-            showNoteDetailView()
-        }
     }
     
     private func showAuthentication() {
@@ -157,6 +153,8 @@ extension NotesViewController: NotesViewControllerDelegate {
         PersistentManager.shared.delete(item)
         tableView.deleteRows(at: [indexPath], with: .fade)
         changeSelectedIndex(indexPath: indexPath)
+        delegate?.clearTextView()
+        showNoteDetailView()
     }
     
     private func changeSelectedIndex(indexPath: IndexPath) {

--- a/CloudNotes/CloudNotes/Controller/NotesViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/NotesViewController.swift
@@ -17,12 +17,28 @@ class NotesViewController: UITableViewController {
         }
     }
     
+    lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView()
+        activityIndicator.center = self.splitViewController?.view.center ?? CGPoint()
+        activityIndicator.style = UIActivityIndicatorView.Style.large
+        activityIndicator.startAnimating()
+        activityIndicator.isHidden = false
+        return activityIndicator
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpNavigationItem()
         tableView.allowsSelectionDuringEditing = true
         tableView.register(NotesCell.self, forCellReuseIdentifier: NotesCell.identifier)
         dropBoxManager.authorize(self)
+        splitViewController?.view.addSubview(activityIndicator)
+        view.isUserInteractionEnabled = false
+    }
+    
+    func stopActivityIndicator() {
+        activityIndicator.stopAnimating()
+        view.isUserInteractionEnabled = true
     }
     
     override func setEditing(_ editing: Bool, animated: Bool) {

--- a/CloudNotes/CloudNotes/Controller/NotesViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/NotesViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftyDropbox
 
 class NotesViewController: UITableViewController {
     private enum Constant {
@@ -20,6 +21,20 @@ class NotesViewController: UITableViewController {
         setUpNavigationItem()
         tableView.allowsSelectionDuringEditing = true
         tableView.register(NotesCell.self, forCellReuseIdentifier: NotesCell.identifier)
+        authorize()
+    }
+    
+    func authorize() {
+        let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
+        DropboxClientsManager.authorizeFromControllerV2(
+            UIApplication.shared,
+            controller: self,
+            loadingStatusDelegate: nil,
+            openURL: { (url: URL) -> Void in
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            },
+            scopeRequest: scopeRequest
+        )
     }
     
     override func setEditing(_ editing: Bool, animated: Bool) {

--- a/CloudNotes/CloudNotes/Controller/NotesViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/NotesViewController.swift
@@ -9,7 +9,7 @@ class NotesViewController: UITableViewController {
         static let deleteIconName = "trash.fill"
         static let shareIconName = "square.and.arrow.up"
     }
-    let dropBoxManager = DropBoxManager()
+    let dropBoxManager = DropboxManager()
     weak var delegate: NotesDetailViewControllerDelegate?
     private var selectedIndex: IndexPath? {
         didSet {

--- a/CloudNotes/CloudNotes/Controller/NotesViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/NotesViewController.swift
@@ -9,6 +9,7 @@ class NotesViewController: UITableViewController {
         static let deleteIconName = "trash.fill"
         static let shareIconName = "square.and.arrow.up"
     }
+    let dropBoxManager = DropBoxManager()
     weak var delegate: NotesDetailViewControllerDelegate?
     private var selectedIndex: IndexPath? {
         didSet {
@@ -21,20 +22,7 @@ class NotesViewController: UITableViewController {
         setUpNavigationItem()
         tableView.allowsSelectionDuringEditing = true
         tableView.register(NotesCell.self, forCellReuseIdentifier: NotesCell.identifier)
-        authorize()
-    }
-    
-    func authorize() {
-        let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
-        DropboxClientsManager.authorizeFromControllerV2(
-            UIApplication.shared,
-            controller: self,
-            loadingStatusDelegate: nil,
-            openURL: { (url: URL) -> Void in
-                UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            },
-            scopeRequest: scopeRequest
-        )
+        dropBoxManager.authorize(self)
     }
     
     override func setEditing(_ editing: Bool, animated: Bool) {

--- a/CloudNotes/CloudNotes/Controller/NotesViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/NotesViewController.swift
@@ -17,28 +17,12 @@ class NotesViewController: UITableViewController {
         }
     }
     
-    lazy var activityIndicator: UIActivityIndicatorView = {
-        let activityIndicator = UIActivityIndicatorView()
-        activityIndicator.center = self.splitViewController?.view.center ?? CGPoint()
-        activityIndicator.style = UIActivityIndicatorView.Style.large
-        activityIndicator.startAnimating()
-        activityIndicator.isHidden = false
-        return activityIndicator
-    }()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpNavigationItem()
         tableView.allowsSelectionDuringEditing = true
         tableView.register(NotesCell.self, forCellReuseIdentifier: NotesCell.identifier)
-        dropBoxManager.authorize(self)
-        splitViewController?.view.addSubview(activityIndicator)
-        view.isUserInteractionEnabled = false
-    }
-    
-    func stopActivityIndicator() {
-        activityIndicator.stopAnimating()
-        view.isUserInteractionEnabled = true
+        showAuthentication()
     }
     
     override func setEditing(_ editing: Bool, animated: Bool) {
@@ -48,6 +32,12 @@ class NotesViewController: UITableViewController {
             delegate?.clearTextView()
             showNoteDetailView()
         }
+    }
+    
+    private func showAuthentication() {
+        let authenticationViewController = AuthenticationViewController()
+        authenticationViewController.modalPresentationStyle = .overFullScreen
+        present(authenticationViewController, animated: false, completion: nil)
     }
     
     private func showNoteDetailView() {

--- a/CloudNotes/CloudNotes/Error/DropboxError.swift
+++ b/CloudNotes/CloudNotes/Error/DropboxError.swift
@@ -2,11 +2,14 @@ import Foundation
 
 enum DropboxError: LocalizedError {
     case failureDownload
+    case failureUpload
     
     var errorDescription: String? {
         switch self {
         case .failureDownload:
             return "다운로드를 실패하였습니다."
+        case .failureUpload:
+            return "업로드를 실패하였습니다."
         }
     }
 }

--- a/CloudNotes/CloudNotes/Error/DropboxError.swift
+++ b/CloudNotes/CloudNotes/Error/DropboxError.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum DropboxError: LocalizedError {
+    case failureDownload
+    
+    var errorDescription: String? {
+        switch self {
+        case .failureDownload:
+            return "다운로드를 실패하였습니다."
+        }
+    }
+}

--- a/CloudNotes/CloudNotes/Info.plist
+++ b/CloudNotes/CloudNotes/Info.plist
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string></string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>db-zblgyro9xyhr2xo</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>dbapi-8-emm</string>
+		<string>dbapi-2</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/CloudNotes/CloudNotes/Info.plist
+++ b/CloudNotes/CloudNotes/Info.plist
@@ -3,21 +3,21 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLName</key>
-			<string></string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>db-zblgyro9xyhr2xo</string>
-			</array>
-		</dict>
-	</array>
+        <array>
+            <dict>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>db-zblgyro9xyhr2xo</string>
+                </array>
+                <key>CFBundleURLName</key>
+                <string></string>
+            </dict>
+        </array>
 	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>dbapi-8-emm</string>
-		<string>dbapi-2</string>
-	</array>
+        <array>
+            <string>dbapi-8-emm</string>
+            <string>dbapi-2</string>
+        </array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -22,19 +22,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        let splitVC = self.window?.rootViewController as? SplitViewController
+        let primaryVC = splitVC?.viewController(for: .primary) as? NotesViewController
         // MARK: - Dropbox Redirection
         let oauthCompletion: DropboxOAuthCompletion = {
              if let authResult = $0 {
                  switch authResult {
                  case .success:
                      print("Success! User is logged into DropboxClientsManager.")
-                     let splitVC = self.window?.rootViewController as? SplitViewController
-                     let primaryVC = splitVC?.viewController(for: .primary) as? UITableViewController
                      DropBoxManager().download(primaryVC)
                  case .cancel:
                      print("Authorization flow was manually canceled by user!")
+                     primaryVC?.stopActivityIndicator()
                  case .error(_, let description):
                      print("Error: \(String(describing: description))")
+                     primaryVC?.stopActivityIndicator()
                  }
              }
            }

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -8,7 +8,7 @@ import UIKit
 import SwiftyDropbox
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
@@ -26,56 +26,68 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let primaryVC = splitVC?.viewController(for: .primary) as? NotesViewController
         // MARK: - Dropbox Redirection
         let oauthCompletion: DropboxOAuthCompletion = {
-             if let authResult = $0 {
-                 switch authResult {
-                 case .success:
-                     print("Success! User is logged into DropboxClientsManager.")
-                     DropboxManager().download(primaryVC)
-                 case .cancel:
-                     print("Authorization flow was manually canceled by user!")
-                     primaryVC?.stopActivityIndicator()
-                 case .error(_, let description):
-                     print("Error: \(String(describing: description))")
-                     primaryVC?.stopActivityIndicator()
-                 }
-             }
-           }
-
-           for context in URLContexts {
-               if DropboxClientsManager.handleRedirectURL(context.url, completion: oauthCompletion) { break }
-           }
+            if let authResult = $0 {
+                switch authResult {
+                case .success:
+                    print("Success! User is logged into DropboxClientsManager.")
+                    DropboxManager().download() { error in
+                        if error != nil {
+                            primaryVC?.dismiss(animated: false) {
+                                primaryVC?.showAlert(message: "다운로드에 실패했습니다.")
+                            }
+                        } else {
+                            PersistentManager.shared.setUpNotes()
+                            primaryVC?.tableView.reloadData()
+                            primaryVC?.dismiss(animated: false)
+                        }
+                    }
+                case .cancel:
+                    print("Authorization flow was manually canceled by user!")
+                    primaryVC?.dismiss(animated: false)
+                case .error(_, let description):
+                    print("Error: \(String(describing: description))")
+                    primaryVC?.dismiss(animated: false) {
+                        primaryVC?.showAlert(message: "알 수 없는 에러가 발생했습니다.")
+                    }
+                }
+            }
+        }
+        
+        for context in URLContexts {
+            if DropboxClientsManager.handleRedirectURL(context.url, completion: oauthCompletion) { break }
+        }
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
-
+        
         // Save changes in the application's managed object context when the application transitions to the background.
     }
-
-
+    
+    
 }
 

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -5,6 +5,7 @@
 // 
 
 import UIKit
+import SwiftyDropbox
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -19,6 +20,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let splitVC = SplitViewController(style: .doubleColumn)
         window?.rootViewController = splitVC
         window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        // MARK: - Dropbox Redirection
+        let oauthCompletion: DropboxOAuthCompletion = {
+             if let authResult = $0 {
+                 switch authResult {
+                 case .success:
+                     print("Success! User is logged into DropboxClientsManager.")
+                 case .cancel:
+                     print("Authorization flow was manually canceled by user!")
+                 case .error(_, let description):
+                     print("Error: \(String(describing: description))")
+                 }
+             }
+           }
+
+           for context in URLContexts {
+               if DropboxClientsManager.handleRedirectURL(context.url, completion: oauthCompletion) { break }
+           }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -24,18 +24,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         let splitVC = self.window?.rootViewController as? SplitViewController
         let primaryVC = splitVC?.viewController(for: .primary) as? NotesViewController
+
         // MARK: - Dropbox Redirection
         let oauthCompletion: DropboxOAuthCompletion = {
             if let authResult = $0 {
                 switch authResult {
                 case .success:
                     print("Success! User is logged into DropboxClientsManager.")
-                    DropboxManager().download() { error in
-                        if error != nil {
+                    DropboxManager().download() { result in
+                        switch result {
+                        case .failure(let error):
                             primaryVC?.dismiss(animated: false) {
-                                primaryVC?.showAlert(message: "다운로드에 실패했습니다.")
+                                primaryVC?.showAlert(message: error.localizedDescription)
                             }
-                        } else {
+                        case .success:
                             PersistentManager.shared.setUpNotes()
                             primaryVC?.tableView.reloadData()
                             primaryVC?.dismiss(animated: false)

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -30,7 +30,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                  switch authResult {
                  case .success:
                      print("Success! User is logged into DropboxClientsManager.")
-                     DropBoxManager().download(primaryVC)
+                     DropboxManager().download(primaryVC)
                  case .cancel:
                      print("Authorization flow was manually canceled by user!")
                      primaryVC?.stopActivityIndicator()

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -10,8 +10,7 @@ import SwiftyDropbox
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windoewScene = (scene as? UIWindowScene) else {
             return

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -28,6 +28,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                  switch authResult {
                  case .success:
                      print("Success! User is logged into DropboxClientsManager.")
+                     let splitVC = self.window?.rootViewController as? SplitViewController
+                     let primaryVC = splitVC?.viewController(for: .primary) as? UITableViewController
+                     DropBoxManager().download(primaryVC)
                  case .cancel:
                      print("Authorization flow was manually canceled by user!")
                  case .error(_, let description):

--- a/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
@@ -1,0 +1,49 @@
+import SwiftyDropbox
+import UIKit
+
+class DropBoxManager {
+    let client = DropboxClientsManager.authorizedClient
+    let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    let fileNames: [String] = ["/CloudNotes.sqlite", "/CloudNotes.sqlite-shm", "/CloudNotes.sqlite-wal"]
+    let scope = [
+        "account_info.read",
+        "account_info.write",
+        "files.content.read",
+        "files.content.write",
+        "files.metadata.read",
+        "files.metadata.write"
+    ]
+    
+    func authorize(_ viewController: UIViewController) {
+        let scopeRequest = ScopeRequest(
+            scopeType: .user,
+            scopes: scope,
+            includeGrantedScopes: false)
+        DropboxClientsManager.authorizeFromControllerV2(
+            UIApplication.shared,
+            controller: viewController,
+            loadingStatusDelegate: nil,
+            openURL: { (url: URL) -> Void in
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            },
+            scopeRequest: scopeRequest
+        )
+    }
+    
+    func upload() {
+        for fileName in fileNames {
+            let fileURL = url.appendingPathComponent(fileName)
+            client?.files.upload(path: fileName, input: fileURL)
+                .response { response, error in
+                    if let response = response {
+                        print(response)
+                    } else if let error = error {
+                        print(error)
+                    }
+                }
+                .progress { progressData in
+                    print(progressData)
+                }
+        }
+    }
+}

--- a/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
@@ -53,7 +53,7 @@ class DropBoxManager {
         }
     }
     
-    func download(_ tableViewController: UITableViewController?) {
+    func download(_ tableViewController: NotesViewController?) {
         let group = DispatchGroup()
         for fileName in fileNames {
             let destURL = url.appendingPathComponent(fileName)
@@ -77,6 +77,7 @@ class DropBoxManager {
         group.notify(queue: .main) {
             PersistentManager.shared.setUpNotes()
             tableViewController?.tableView.reloadData()
+            tableViewController?.stopActivityIndicator()
         }
     }
 }

--- a/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
@@ -33,7 +33,33 @@ class DropBoxManager {
     func upload() {
         for fileName in fileNames {
             let fileURL = url.appendingPathComponent(fileName)
-            client?.files.upload(path: fileName, input: fileURL)
+            client?.files.upload(
+                path: fileName,
+                mode: .overwrite,
+                autorename: true,
+                mute: true,
+                strictConflict: false,
+                input: fileURL
+            ).response { response, error in
+                    if let response = response {
+                        print(response)
+                    } else if let error = error {
+                        print(error)
+                    }
+                }
+                .progress { progressData in
+                    print(progressData)
+                }
+        }
+    }
+    
+    func download() {
+        for fileName in fileNames {
+            let destURL = url.appendingPathComponent(fileName)
+            let destination: (URL, HTTPURLResponse) -> URL = { _, _ in
+                return destURL
+            }
+            client?.files.download(path: fileName, overwrite: true, destination: destination)
                 .response { response, error in
                     if let response = response {
                         print(response)

--- a/CloudNotes/CloudNotes/Utility/DropboxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropboxManager.swift
@@ -1,11 +1,14 @@
 import SwiftyDropbox
 import UIKit
 
-class DropBoxManager {
-    let client = DropboxClientsManager.authorizedClient
-    let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-    let fileNames: [String] = ["/CloudNotes.sqlite", "/CloudNotes.sqlite-shm", "/CloudNotes.sqlite-wal"]
-    let scope = [
+struct DropboxManager {
+    private let client = DropboxClientsManager.authorizedClient
+    private let applicationSupportDirectoryURl = FileManager.default.urls(
+        for: .applicationSupportDirectory,
+        in: .userDomainMask
+    )[0]
+    private let fileNames: [String] = ["/CloudNotes.sqlite", "/CloudNotes.sqlite-shm", "/CloudNotes.sqlite-wal"]
+    private let scopes = [
         "account_info.read",
         "account_info.write",
         "files.content.read",
@@ -17,7 +20,7 @@ class DropBoxManager {
     func authorize(_ viewController: UIViewController) {
         let scopeRequest = ScopeRequest(
             scopeType: .user,
-            scopes: scope,
+            scopes: scopes,
             includeGrantedScopes: false)
         DropboxClientsManager.authorizeFromControllerV2(
             UIApplication.shared,
@@ -32,7 +35,7 @@ class DropBoxManager {
     
     func upload() {
         for fileName in fileNames {
-            let fileURL = url.appendingPathComponent(fileName)
+            let fileURL = applicationSupportDirectoryURl.appendingPathComponent(fileName)
             client?.files.upload(
                 path: fileName,
                 mode: .overwrite,
@@ -56,7 +59,7 @@ class DropBoxManager {
     func download(_ tableViewController: NotesViewController?) {
         let group = DispatchGroup()
         for fileName in fileNames {
-            let destURL = url.appendingPathComponent(fileName)
+            let destURL = applicationSupportDirectoryURl.appendingPathComponent(fileName)
             let destination: (URL, HTTPURLResponse) -> URL = { _, _ in
                 return destURL
             }

--- a/CloudNotes/CloudNotes/Utility/DropboxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropboxManager.swift
@@ -57,7 +57,7 @@ struct DropboxManager {
         }
         group.notify(queue: .main) {
             if hasErrorOccured {
-                complition?(.failure(DropboxError.failureDownload))
+                complition?(.failure(DropboxError.failureUpload))
             } else {
                 complition?(.success(true))
             }

--- a/CloudNotes/CloudNotes/Utility/DropboxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropboxManager.swift
@@ -52,7 +52,7 @@ struct DropboxManager {
         }
     }
     
-    func download(_ tableViewController: NotesViewController?) {
+    func download(complition: ((CallError<Files.DownloadError>?) -> Void)?) {
         let group = DispatchGroup()
         for fileName in fileNames {
             let destURL = applicationSupportDirectoryURL.appendingPathComponent(fileName)
@@ -64,14 +64,13 @@ struct DropboxManager {
                 .response { _, error in
                     if let error = error {
                         print(error)
+                        complition?(error)
                     }
                     group.leave()
                 }
         }
         group.notify(queue: .main) {
-            PersistentManager.shared.setUpNotes()
-            tableViewController?.tableView.reloadData()
-            tableViewController?.stopActivityIndicator()
+            complition?(nil)
         }
     }
 }

--- a/CloudNotes/CloudNotes/Utility/PersistentManager.swift
+++ b/CloudNotes/CloudNotes/Utility/PersistentManager.swift
@@ -59,11 +59,10 @@ extension PersistentManager {
 
 // MARK: - CRUD
 extension PersistentManager {
-    @discardableResult
-    func insert(entityName: String = "Note", items: [String: Any]) -> Note? {
+    func insert(entityName: String = "Note", items: [String: Any]) {
         let context = persistentContainer.viewContext
         let managedObject = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
-        return update(managedObject, items: items)
+        update(managedObject, items: items)
     }
     
     @discardableResult
@@ -83,8 +82,7 @@ extension PersistentManager {
         return newData
     }
     
-    @discardableResult
-    func update(_ managedObject: NSManagedObject, items: [String: Any]) -> Note? {
+    func update(_ managedObject: NSManagedObject, items: [String: Any]) {
         let keys = managedObject.entity.attributesByName.keys
         for key in keys {
             if let value = items[key] {
@@ -93,7 +91,6 @@ extension PersistentManager {
         }
         saveContext()
         fetch()
-        return managedObject as? Note
     }
     
     func delete(_ item: Note) {
@@ -107,7 +104,7 @@ extension PersistentManager {
         entityName: String = "Note",
         items: [String: Any]
     ) {
-        _ = items["id"]
+        items["id"]
             .flatMap { $0 as? UUID as CVarArg? }
             .flatMap { fetch(entityName: entityName, predicate: NSPredicate(format: "id == %@", $0))?.first }
             .flatMap { $0 as NSManagedObject }

--- a/CloudNotes/CloudNotes/Utility/PersistentManager.swift
+++ b/CloudNotes/CloudNotes/Utility/PersistentManager.swift
@@ -105,21 +105,12 @@ extension PersistentManager {
 
     func updateNote(
         entityName: String = "Note",
-        id: UUID?,
-        title: String?,
-        body: String?,
-        lastModified: TimeInterval
+        items: [String: Any]
     ) {
-        guard let id = id else {
-            return
-        }
-        let predicate = NSPredicate(format: "id == %@", id as CVarArg)
-        guard let note = fetch(entityName: entityName, predicate: predicate)?.first else {
-            return
-        }
-        note.title = title
-        note.body = body
-        note.lastModified = lastModified
-        saveContext()
+        _ = items["id"]
+            .flatMap { $0 as? UUID as CVarArg? }
+            .flatMap { fetch(entityName: entityName, predicate: NSPredicate(format: "id == %@", $0))?.first }
+            .flatMap { $0 as NSManagedObject }
+            .flatMap { update($0, items: items) }
     }
 }

--- a/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
+++ b/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
@@ -9,7 +9,7 @@ extension UIViewController {
 
     @objc func dismissKeyboard() {
         view.endEditing(true)
-        DropBoxManager().upload()
+        DropboxManager().upload()
     }
     
     func showActivityViewController(data: String...) {

--- a/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
+++ b/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
@@ -14,7 +14,7 @@ extension UIViewController {
             case .success:
                 print("업로드 성공")
             case .failure(let error):
-                self.showAlert(message: error.localizedDescription)
+                print(error.localizedDescription)
             }
         }
     }

--- a/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
+++ b/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
@@ -60,11 +60,18 @@ extension UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    func showAlert(message: String, actionTitle: String, handler: @escaping (UIAlertAction) -> Void) {
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+    func showAlert(message: String, actionTitle: String, handler: ((UIAlertAction) -> Void)? = nil) {
+        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "cancel", style: .default, handler: nil)
         let okAction = UIAlertAction(title: actionTitle, style: .destructive, handler: handler)
         alert.addAction(cancelAction)
+        alert.addAction(okAction)
+        present(alert, animated: true, completion: nil)
+    }
+    
+    func showAlert(message: String, handler: ((UIAlertAction) -> Void)? = nil) {
+        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: handler)
         alert.addAction(okAction)
         present(alert, animated: true, completion: nil)
     }

--- a/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
+++ b/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
@@ -9,7 +9,14 @@ extension UIViewController {
 
     @objc func dismissKeyboard() {
         view.endEditing(true)
-        DropboxManager().upload()
+        DropboxManager().upload { result in
+            switch result {
+            case .success:
+                print("업로드 성공")
+            case .failure(let error):
+                self.showAlert(message: error.localizedDescription)
+            }
+        }
     }
     
     func showActivityViewController(data: String...) {

--- a/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
+++ b/CloudNotes/CloudNotes/extension/UIViewController+extension.swift
@@ -9,6 +9,7 @@ extension UIViewController {
 
     @objc func dismissKeyboard() {
         view.endEditing(true)
+        DropBoxManager().upload()
     }
     
     func showActivityViewController(data: String...) {

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@
     + [Trouble Shooting](#2-3-Trouble-Shooting)
     + [배운 개념](#2-4-배운-개념)
     + [PR 후 개선사항](#2-5-PR-후-개선사항)
-
+- [STEP 3 : 클라우드 연동](#STEP-3--클라우드-연동)
+    + [고민했던 것](#3-1-고민했던-것)
+    + [의문점](#3-2-의문점)
+    + [Trouble Shooting](#3-3-Trouble-Shooting)
+    + [배운 개념](#3-4-배운-개념)
 
 ## ⌨️ 키워드
 
@@ -760,6 +764,203 @@ func download(_ tableViewController: NotesViewController?) {
 ![](https://i.imgur.com/ejnhQOL.png)
 
 > `SwiftyDropbox`가 정상적으로 설치된 것을 확인할 수 있다.
+
+</div>
+</details>
+
+
+<details>
+<summary>[프로젝트에 SwiftyDropbox 설정하기]</summary>
+<div markdown="1">
+
+> 아래 프로젝트 설정하는 튜토리얼을 참고하여 진행하였다.
+https://github.com/dropbox/SwiftyDropbox#configure-your-project
+
+> 먼저 Info.plist 파일을 수정해주어야 하는데, 그 전에 dropbox에 app을 등록해야 한다. 로그인 후 apps에 들어가면 아래와 같은 버튼이 있다.
+
+![](https://i.imgur.com/xBg2zZc.png)
+
+> 이후 필수 문항을 선택, 입력 후 create app 버튼을 눌러 만들어주면 된다.
+
+![](https://i.imgur.com/mqSylZ5.png)
+
+> 그러면 App key가 발급되는데, 이걸 이제 Info.plist를 수정하는데 활용할 것이다.
+
+![](https://i.imgur.com/QuHdJk5.png)
+
+튜토리얼에서 하라는데로 Info.plist를 예시와 같이 수정해준다.
+
+```
+<key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>dbapi-8-emm</string>
+        <string>dbapi-2</string>
+    </array>
+```
+
+> 아까 만들고 얻은 App key를 `db-` 뒤부터 기입해주면 된다.
+```
+<key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>db-<APP_KEY></string>
+            </array>
+            <key>CFBundleURLName</key>
+            <string></string>
+        </dict>
+    </array>
+```
+
+![](https://i.imgur.com/ltONNs1.png)
+
+> 이후 코드로 돌아가서 AppDelegate에 DropboxClient 인스턴스를 초기화 해준다.
+
+```swift
+import SwiftyDropbox
+
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    DropboxClientsManager.setupWithAppKey("<APP_KEY>")
+    return true
+}
+```
+
+> 그리고 SceneDelegate에 아래와 같은 메소드를 추가한다.
+
+```swift
+import SwiftyDropbox
+
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+     let oauthCompletion: DropboxOAuthCompletion = {
+      if let authResult = $0 {
+          switch authResult {
+          case .success:
+              print("Success! User is logged into DropboxClientsManager.")
+          case .cancel:
+              print("Authorization flow was manually canceled by user!")
+          case .error(_, let description):
+              print("Error: \(String(describing: description))")
+          }
+      }
+    }
+
+    for context in URLContexts {
+        // stop iterating after the first handle-able url
+        if DropboxClientsManager.handleRedirectURL(context.url, completion: oauthCompletion) { break }
+    }
+}
+    }
+```
+
+> 이후 맨처음에 시작하는 뷰에 로그인을 해서 인증 토큰을 받아오는 작업을 추가한다. 이번 프로젝트 같은 경우 UISplitViewController를 사용했는데, rootView인 SplitViewController에서는 해당 작업이 정상적으로 뜨지않았다. (이유는 찾지 못했다.) 그래서 다른 UIViewController에서 진행해야하나.. 싶어서 UITableViewController의 viewDidLoad()에서 해당 작업을 실행해주니 로그인창이 정상적으로 떴다.
+
+```swift
+import SwiftyDropbox
+
+func myButtonInControllerPressed() {
+    // OAuth 2 code flow with PKCE that grants a short-lived token with scopes, and performs refreshes of the token automatically.
+    let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
+    DropboxClientsManager.authorizeFromControllerV2(
+        UIApplication.shared,
+        controller: self,
+        loadingStatusDelegate: nil,
+        openURL: { (url: URL) -> Void in UIApplication.shared.open(url, options: [:], completionHandler: nil) },
+        scopeRequest: scopeRequest
+    )
+
+    // Note: this is the DEPRECATED authorization flow that grants a long-lived token.
+    // If you are still using this, please update your app to use the `authorizeFromControllerV2` call instead.
+    // See https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens
+    DropboxClientsManager.authorizeFromController(UIApplication.shared,
+                                                  controller: self,
+                                                  openURL: { (url: URL) -> Void in
+                                                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                                                  })
+}
+```
+
+> 여기서 scopes라는 파라미터가 있는데, 이 부분은 앱이 Dropbox 계정 정보를 보고 관리할 수 있도록 권한의 범위를 뜻한다. 아까 App key를 얻었던 곳에서 Permissions 탭을 클릭하면 Account의 정보가 나온다. 따라서 필요한 Account를 scopes에 넣어주면 되겠다.
+
+![](https://i.imgur.com/1O8bJws.jpg)
+
+
+> 이 다음에 API에 호출할 DropboxClient 인스턴스를 생성한다.
+
+```swift
+import SwiftyDropbox
+
+// Reference after programmatic auth flow
+let client = DropboxClientsManager.authorizedClient
+```
+
+> client를 통해 업로드와 다운로드를 진행할 수 있다.
+
+```swift
+let fileData = "testing data example".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+
+let request = client.files.upload(path: "/test/path/in/Dropbox/account", input: fileData)
+    .response { response, error in
+        if let response = response {
+            print(response)
+        } else if let error = error {
+            print(error)
+        }
+    }
+    .progress { progressData in
+        print(progressData)
+    }
+
+// in case you want to cancel the request
+if someConditionIsSatisfied {
+    request.cancel()
+}
+```
+
+```swift
+// Download to URL
+let fileManager = FileManager.default
+let directoryURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+let destURL = directoryURL.appendingPathComponent("myTestFile")
+let destination: (URL, HTTPURLResponse) -> URL = { temporaryURL, response in
+    return destURL
+}
+client.files.download(path: "/test/path/in/Dropbox/account", overwrite: true, destination: destination)
+    .response { response, error in
+        if let response = response {
+            print(response)
+        } else if let error = error {
+            print(error)
+        }
+    }
+    .progress { progressData in
+        print(progressData)
+    }
+
+
+// Download to Data
+client.files.download(path: "/test/path/in/Dropbox/account")
+    .response { response, error in
+        if let response = response {
+            let responseMetadata = response.0
+            print(responseMetadata)
+            let fileContents = response.1
+            print(fileContents)
+        } else if let error = error {
+            print(error)
+        }
+    }
+    .progress { progressData in
+        print(progressData)
+    }
+```
+
+> 두가지의 공통점은 파일을 다운로드하고, 업로드할 때 `경로`가 필요하다는 점이다. 메모장 프로젝트의 경우 CoreData를 통해서 메모를 관리하고 있기 때문에 `백업`의 형태로 CoreData의 경로를 얻어내서 `.sqlite`, `.sqlite-shm`, `.sqlite-wal` 총 3개의 파일을 업로드 및 다운로드 해주도록 구현해주었다.
+
+> 업로드, 다운로드 모두 파일을 덮어쓸건지에 대한 옵션이 있으니 자세한건 아래 도큐먼트에서 검색해보면 되겠다.
+
+https://dropbox.github.io/SwiftyDropbox/api-docs/latest/index.html
+
 
 </div>
 </details>


### PR DESCRIPTION
안녕하세요. 웨더! @SungPyo

호박 @hoBahk 아리 @leeari95 입니다!
STEP3 요구사항 모두 구현하여 PR 보내드립니다.

저번 온라인 리뷰때 뭔가 시야가 탁...트인... 그런 시원~~한 기분을 맛보았어요. 덕분에 많이 배워갑니다. 🤩
이번에도 부족한 점이나 놓친 부분이 있다면 한번 더 짚어주시면 감사하겠습니다. 🙇🏻‍♀️

# 고민했던 점

### 1. 업로드 시점

* 여러 고민을 한 결과 키보드를 내릴 때 마다 업로드를 하도록 하여 업로드가 빈번하게 일어나지 않도록 하였고 의도치 않게 종료되어도 방어를 할 수 있도록 구현하였습니다.

### 2. 다운로드의 시점

* 다운로드 시점은 처음에 사용자가 로그인을 성공하는 시점에 dropbox의 데이터를 다운로드 하여 보여주는 주도록 구현하길 원했습니다. 그래서 인증이 완료 되고 authResult(인증결과)가 success가 되면 download를 하도록 구현하였습니다.
* 또한, 다운로드는 비동기로 진행이 되기 떄문에 DispatchGroup을 사용하여 다운로드가 완료되면 앱에 데이터를 뿌려주고 테이블뷰를 업데이트 하도록 구현하였습니다.

### 3. 다운로드가 진행중일 때 뷰의 상태

* 다운로드를 요청하고 ActivityIndicator를 사용자에게 보여주도록 하고 다운로드가 모두 완료되면 ActivityIndicator는 종료하고 데이터를 사용자에게 보여주도록 구현하였습니다.

# 궁금했던 것 / 조언이 필요한 점

### 1. 업로드 시점이 괜찮은지

* 현재 키보드를 내렸을 때 업로드를 하도록 구현했습니다. 너무 빈번하지도 않으면서 중간중간에 업로드를 할 수 있을 것 같아서... 이렇게 구현하였는데요.
* 웨더가 생각하실때 더 좋은 업로드 시점이 있을까요? 🤔 현업에서의 보편적인 동기화 시점은 언제인지 궁금합니다!

### 2. 강제종료 되었을 때 대처할 수 있는 방법

* 위의 질문과 연결되는 질문입니다. 키보드를 내릴 때 업로드를 하는 것은 강제종료 되었을 때를 완벽히 방어할 수는 없을 것 같습니다.
* 그래서 강제종료 되었을 때 사용할 수 있는 라이프 사이클이나 유사한 기능을 하는 메서드 혹은 방법이 있을까요? 웨더의 도움이 필요합니다!🙏

이번 피드백도 잘 부탁드리겠습니다~ 😁🙏🏻