### PR TITLE
동기화 메모장 [STEP3/STEP4] Jiseong, Toni, 애플사이다

### DIFF
--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2D44BD0C81E0E030EC0E88B8 /* Pods_CloudNotesTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 662797D95146A7CA1DE8772A /* Pods_CloudNotesTests.framework */; };
 		3626675027B20BC200622FC3 /* MainSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3626674F27B20BC200622FC3 /* MainSplitViewController.swift */; };
 		364359E527BA33F300F95297 /* AlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364359E427BA33F300F95297 /* AlertFactory.swift */; };
+		367B1E4F27C8C95B00F1471E /* SearchResultTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367B1E4E27C8C95B00F1471E /* SearchResultTableViewController.swift */; };
 		3682BC4B27C37D9100BBDCA5 /* MemoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3682BC4A27C37D9100BBDCA5 /* MemoEntity.swift */; };
 		36E2C84A27B630C7004C8F7D /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E2C84927B630C7004C8F7D /* UITableViewCell+Identifier.swift */; };
 		531A8D5527C61F55007943A0 /* DropBoxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531A8D5427C61F55007943A0 /* DropBoxManager.swift */; };
@@ -56,6 +57,7 @@
 		0767BFBCC35C70D8FF097F02 /* Pods_CloudNotes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CloudNotes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3626674F27B20BC200622FC3 /* MainSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSplitViewController.swift; sourceTree = "<group>"; };
 		364359E427BA33F300F95297 /* AlertFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertFactory.swift; sourceTree = "<group>"; };
+		367B1E4E27C8C95B00F1471E /* SearchResultTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResultTableViewController.swift; sourceTree = "<group>"; };
 		3682BC4A27C37D9100BBDCA5 /* MemoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEntity.swift; sourceTree = "<group>"; };
 		36E2C84927B630C7004C8F7D /* UITableViewCell+Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Identifier.swift"; sourceTree = "<group>"; };
 		48336AE6FA6AF885936EB6F0 /* Pods-CloudNotes.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudNotes.debug.xcconfig"; path = "Target Support Files/Pods-CloudNotes/Pods-CloudNotes.debug.xcconfig"; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				538B2C4327B2351B00C31617 /* MasterTableViewController.swift */,
 				A6B0103B27B60DFD00D70609 /* MasterTableViewDataSource.swift */,
 				C7481C7125BBCF3900B9CA55 /* DetailViewController.swift */,
+				367B1E4E27C8C95B00F1471E /* SearchResultTableViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -534,6 +537,7 @@
 				531A8D5527C61F55007943A0 /* DropBoxManager.swift in Sources */,
 				C7481C7225BBCF3900B9CA55 /* DetailViewController.swift in Sources */,
 				3682BC4B27C37D9100BBDCA5 /* MemoEntity.swift in Sources */,
+				367B1E4F27C8C95B00F1471E /* SearchResultTableViewController.swift in Sources */,
 				C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */,
 				A68A845727BB494A0035BD96 /* TemporaryMemo.swift in Sources */,
 				364359E527BA33F300F95297 /* AlertFactory.swift in Sources */,

--- a/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
+++ b/CloudNotes/CloudNotes.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,6 +12,7 @@
 		364359E527BA33F300F95297 /* AlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364359E427BA33F300F95297 /* AlertFactory.swift */; };
 		3682BC4B27C37D9100BBDCA5 /* MemoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3682BC4A27C37D9100BBDCA5 /* MemoEntity.swift */; };
 		36E2C84A27B630C7004C8F7D /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36E2C84927B630C7004C8F7D /* UITableViewCell+Identifier.swift */; };
+		531A8D5527C61F55007943A0 /* DropBoxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531A8D5427C61F55007943A0 /* DropBoxManager.swift */; };
 		532A8B5827BB8684004591ED /* Memo+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532A8B5627BB8684004591ED /* Memo+CoreDataClass.swift */; };
 		532A8B5927BB8684004591ED /* Memo+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532A8B5727BB8684004591ED /* Memo+CoreDataProperties.swift */; };
 		538B2C4427B2351B00C31617 /* MasterTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538B2C4327B2351B00C31617 /* MasterTableViewController.swift */; };
@@ -60,6 +61,7 @@
 		48336AE6FA6AF885936EB6F0 /* Pods-CloudNotes.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudNotes.debug.xcconfig"; path = "Target Support Files/Pods-CloudNotes/Pods-CloudNotes.debug.xcconfig"; sourceTree = "<group>"; };
 		4E04B2B2FECFEB8C12190639 /* Pods-CloudNotes-CloudNotesUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudNotes-CloudNotesUITests.debug.xcconfig"; path = "Target Support Files/Pods-CloudNotes-CloudNotesUITests/Pods-CloudNotes-CloudNotesUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		50981C50F192DEBD473C418A /* Pods-CloudNotesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudNotesTests.debug.xcconfig"; path = "Target Support Files/Pods-CloudNotesTests/Pods-CloudNotesTests.debug.xcconfig"; sourceTree = "<group>"; };
+		531A8D5427C61F55007943A0 /* DropBoxManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropBoxManager.swift; sourceTree = "<group>"; };
 		532A8B5627BB8684004591ED /* Memo+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Memo+CoreDataClass.swift"; sourceTree = "<group>"; };
 		532A8B5727BB8684004591ED /* Memo+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Memo+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		538B2C4327B2351B00C31617 /* MasterTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterTableViewController.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 			children = (
 				364359E427BA33F300F95297 /* AlertFactory.swift */,
 				A68A845027BA67E00035BD96 /* MemoCoreDataManager.swift */,
+				531A8D5427C61F55007943A0 /* DropBoxManager.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -528,6 +531,7 @@
 				538B2C4627B235B200C31617 /* MasterTableViewCell.swift in Sources */,
 				532A8B5927BB8684004591ED /* Memo+CoreDataProperties.swift in Sources */,
 				532A8B5827BB8684004591ED /* Memo+CoreDataClass.swift in Sources */,
+				531A8D5527C61F55007943A0 /* DropBoxManager.swift in Sources */,
 				C7481C7225BBCF3900B9CA55 /* DetailViewController.swift in Sources */,
 				3682BC4B27C37D9100BBDCA5 /* MemoEntity.swift in Sources */,
 				C7481C6E25BBCF3900B9CA55 /* AppDelegate.swift in Sources */,

--- a/CloudNotes/CloudNotes/AppDelegate.swift
+++ b/CloudNotes/CloudNotes/AppDelegate.swift
@@ -12,7 +12,7 @@ import SwiftyDropbox
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        DropboxClientsManager.setupWithAppKey("cw6gr31z68zgvkm")
+        DropboxClientsManager.setupWithAppKey("bg6xjvljgmkc6ui")
         return true
     }
 

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -171,4 +171,8 @@ extension DetailViewController: UITextViewDelegate {
         let memoToUpdate = createMemoToUpdate()
         NotificationCenter.default.post(name: Notification.Name("didChangeTextView"), object: nil, userInfo: ["memo": memoToUpdate as Any])
     }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        DropBoxManager().uploadToDropBox()
+    }
 }

--- a/CloudNotes/CloudNotes/Controller/DetailViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/DetailViewController.swift
@@ -121,8 +121,10 @@ final class DetailViewController: UIViewController {
     }
     
     private func updateTextView() {
-        let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1)]
-        let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body)]
+        let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1),
+                               NSAttributedString.Key.foregroundColor: UIColor.label]
+        let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
+                              NSAttributedString.Key.foregroundColor: UIColor.label]
         
         let totalAttributedText = NSMutableAttributedString()
         let titleAttributedText = NSMutableAttributedString(string: memo?.title ?? "", attributes: titleAttributes)
@@ -152,8 +154,10 @@ extension DetailViewController: MemoSelectionDelegate {
 
 extension DetailViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1)]
-        let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body)]
+        let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1),
+                               NSAttributedString.Key.foregroundColor: UIColor.label]
+        let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
+                              NSAttributedString.Key.foregroundColor: UIColor.label]
         
         let textAsNSString = textView.text as NSString
         let titleRange = textAsNSString.range(of: "\n")

--- a/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
@@ -31,8 +31,8 @@ final class MasterTableViewController: UITableViewController {
         configureNotificationCenter()
         tableView.reloadData()
         
-//        DropBoxManager().createFolderAtDropBox() // 앱 최초실행 시 폴더를 한 번 생성함 (그 후에는 error를 출력)
-//        DropBoxManager().presentSafariViewController(controller: self) // DropBox 관련 기능
+        DropBoxManager().createFolderAtDropBox() // 앱 최초실행 시 폴더를 한 번 생성함 (그 후에는 error를 출력)
+        DropBoxManager().presentSafariViewController(controller: self) // DropBox 관련 기능
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
@@ -8,7 +8,7 @@ protocol MemoSelectionDelegate: AnyObject {
 
 final class MasterTableViewController: UITableViewController {
     // MARK: - Properties
-    private let memoDataSource: MasterTableViewDataSourceProtocol?
+    private(set) var memoDataSource: MasterTableViewDataSourceProtocol?
     weak var delegate: MemoSelectionDelegate?
     
     // MARK: - Initializer

--- a/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
@@ -29,6 +29,8 @@ final class MasterTableViewController: UITableViewController {
         configureTableView()
         configureNotificationCenter()
         tableView.reloadData()
+        
+        DropBoxManager().createFolderAtDropBox() // 앱 최초실행 시 폴더를 한 번 생성함 (그 후에는 error를 출력)
         DropBoxManager().presentSafariViewController(controller: self) // DropBox 관련 기능
     }
     
@@ -58,6 +60,8 @@ final class MasterTableViewController: UITableViewController {
         tableView.insertRows(at: [firstIndexPath], with: .none)
         tableView(tableView, didSelectRowAt: firstIndexPath)
         tableView.selectRow(at: firstIndexPath, animated: true, scrollPosition: .middle)
+        
+        DropBoxManager().uploadToDropBox()
     }
     
     private func configureTableView() {
@@ -110,6 +114,8 @@ final class MasterTableViewController: UITableViewController {
         memoDataSource?.deleteMemo(with: removedMemo?.memoId)
         tableView.deleteRows(at: [index], with: .fade)
         changeMemoIfNotEmpty()
+        
+        DropBoxManager().uploadToDropBox()
     }
     
     private func changeMemoIfNotEmpty() {

--- a/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/MasterTableViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SwiftyDropbox
 
 protocol MemoSelectionDelegate: AnyObject {
     var memoSelectionDestination: UIViewController { get }
@@ -11,7 +10,6 @@ final class MasterTableViewController: UITableViewController {
     // MARK: - Properties
     private let memoDataSource: MasterTableViewDataSourceProtocol?
     weak var delegate: MemoSelectionDelegate?
-    private let dropBoxClient = DropboxClientsManager.authorizedClient
     
     // MARK: - Initializer
     init(style: UITableView.Style, dataSource: MasterTableViewDataSourceProtocol = MasterTableViewDataSource(), delegate: MemoSelectionDelegate) {
@@ -31,8 +29,7 @@ final class MasterTableViewController: UITableViewController {
         configureTableView()
         configureNotificationCenter()
         tableView.reloadData()
-        
-//        presentSafariViewController()  // DropBox 관련 기능
+        DropBoxManager().presentSafariViewController(controller: self) // DropBox 관련 기능
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -184,71 +181,5 @@ final class MasterTableViewController: UITableViewController {
         shareAction.image = UIImage(systemName: "square.and.arrow.up")
         
         return UISwipeActionsConfiguration(actions: [deleteAction, shareAction])
-    }
-}
-
-extension MasterTableViewController {
-    func presentSafariViewController() {
-        let scopeRequest = ScopeRequest(scopeType: .user, scopes: [
-            "account_info.write",
-            "account_info.read",
-            "files.metadata.write",
-            "files.metadata.read",
-            "files.content.write",
-            "files.content.read",
-            "file_requests.write"], includeGrantedScopes: false)
-        DropboxClientsManager.authorizeFromControllerV2(
-            UIApplication.shared,
-            controller: self,
-            loadingStatusDelegate: nil,
-            openURL: { (url: URL) -> Void in UIApplication.shared.open(url, options: [:], completionHandler: nil) },
-            scopeRequest: scopeRequest
-        )
-    }
-    
-    func createFolderAtDropBox() {
-        dropBoxClient?.files.createFolderV2(path: "/test/path/in/Dropbox/account").response { response, error in
-            if let response = response {
-                print(response)
-            } else if let error = error {
-                print(error)
-            }
-        }
-    }
-    
-    func uploadToDropBox() {
-        let fileData = "testing data example".data(using: String.Encoding.utf8, allowLossyConversion: false)!
-
-        let request = dropBoxClient?.files.upload(path: "/test/path/in/Dropbox/account", mode: .overwrite, autorename: true, clientModified: Date(), mute: false, propertyGroups: nil, strictConflict: false, input: fileData)
-            .response { response, error in
-                if let response = response {
-                    print(response)
-                } else if let error = error {
-                    print(error)
-                }
-            }
-            .progress { progressData in
-                print(progressData)
-            }
-    }
-    
-    func downloadFromDropBox() {
-        let fileManager = FileManager.default
-        let directoryURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        let destURL = directoryURL.appendingPathComponent("myTestFile")
-        let destination: (URL, HTTPURLResponse) -> URL = { _, response in
-            return destURL
-        }
-        dropBoxClient?.files.download(path: "/test/path/in/Dropbox/account", overwrite: true, destination: destination)
-            .response { response, error in
-                if let response = response {
-                    print(response)
-                } else if let error = error {
-                    print(error)
-                }
-            }
-            .progress { progressData in
-                print(progressData)
-            }
     }
 }

--- a/CloudNotes/CloudNotes/Controller/SearchResultTableViewController.swift
+++ b/CloudNotes/CloudNotes/Controller/SearchResultTableViewController.swift
@@ -1,0 +1,69 @@
+import UIKit
+
+final class SearchResultTableViewController: UITableViewController {
+    // MARK: - Properties
+    private(set) var memos: [MemoEntity]?
+    private(set) var filteredMemos: [MemoEntity]?
+    private weak var delegate: MemoSelectionDelegate?
+    
+    // MARK: - Initializer
+    init(style: UITableView.Style = .insetGrouped, memos: [MemoEntity]?, delegate: MemoSelectionDelegate?) {
+        self.memos = memos
+        self.delegate = delegate
+        super.init(style: style)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Methods
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTableView()
+    }
+    
+    private func configureTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(MasterTableViewCell.self, forCellReuseIdentifier: MasterTableViewCell.reuseIdentifier)
+    }
+    
+    func searchMemo(with text: String) {
+        filteredMemos = memos?.filter { memo in
+            ((memo.title ?? "") + (memo.body ?? "")).contains(text)
+        }
+    }
+    
+    // MARK: - Table view data source
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return filteredMemos?.count ?? 0
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withClass: MasterTableViewCell.self, for: indexPath)
+        
+        guard let filteredMemos = filteredMemos else {
+            return UITableViewCell()
+        }
+        
+        cell.configureUI()
+        cell.applyData(filteredMemos[indexPath.row])
+        
+        return cell
+    }
+    
+    // MARK: - Table view delegate
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let destination = delegate?.memoSelectionDestination as? DetailViewController else {
+            return
+        }
+
+        guard let filteredMemos = filteredMemos?[indexPath.row] else {
+            return
+        }
+ 
+        destination.applyData(with: filteredMemos)
+        splitViewController?.showDetailViewController(UINavigationController(rootViewController: destination), sender: self)
+    }
+}

--- a/CloudNotes/CloudNotes/Info.plist
+++ b/CloudNotes/CloudNotes/Info.plist
@@ -9,7 +9,7 @@
 			<string></string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>db-cw6gr31z68zgvkm</string>
+				<string>db-bg6xjvljgmkc6ui</string>
 			</array>
 		</dict>
 	</array>

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -8,19 +8,25 @@ import UIKit
 import SwiftyDropbox
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
+    lazy var mainSplitViewController = MainSplitViewController(masterViewController: masterViewController, detailViewController: detailViewController)
+    lazy var masterViewController = MasterTableViewController(style: .insetGrouped, delegate: detailViewController)
+    let detailViewController = DetailViewController()
+    
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         let oauthCompletion: DropboxOAuthCompletion = {
             if let authResult = $0 {
                 switch authResult {
                 case .success(let token):
                     print("Success! User is logged into Dropbox with token: \(token)")
-                    DropBoxManager().downloadFromDropBox()
-                    // fetch 및 table.reload 처리를 completion으로 해야 함
+                    DropBoxManager().downloadFromDropBox {
+                        self.masterViewController.memoDataSource?.fetchMemos()
+                        self.masterViewController.tableView.reloadData()
+                    }
+
                     
-//                    DropBoxManager().uploadToDropBox() // 테스트하려면 업로드를 먼저 해야 함
+//                  DropBoxManager().uploadToDropBox() // 테스트하려면 업로드를 먼저 해야 함
                 case .cancel:
                     print("Authorization flow was manually canceled by user!")
                 case .error(_, let description):
@@ -28,12 +34,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 }
             }
         }
-
+        
         for context in URLContexts {
             if DropboxClientsManager.handleRedirectURL(context.url, completion: oauthCompletion) { break }
         }
     }
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -41,44 +47,43 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        let detailViewController = DetailViewController()
-        let masterViewController = MasterTableViewController(style: .insetGrouped, delegate: detailViewController)
         
-        let mainSplitViewController = MainSplitViewController(masterViewController: masterViewController, detailViewController: detailViewController)
+        
+        
         window?.rootViewController = mainSplitViewController
         window?.makeKeyAndVisible()
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
-
+        
         // Save changes in the application's managed object context when the application transitions to the background.
     }
-
-
+    
+    
 }
 

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -17,7 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 switch authResult {
                 case .success(let token):
                     print("Success! User is logged into Dropbox with token: \(token)")
-                    DropBoxManager().uploadToDropBox()
+                    DropBoxManager().downloadFromDropBox()
+                    // fetch 및 table.reload 처리를 completion으로 해야 함
+                    
+//                    DropBoxManager().uploadToDropBox() // 테스트하려면 업로드를 먼저 해야 함
                 case .cancel:
                     print("Authorization flow was manually canceled by user!")
                 case .error(_, let description):

--- a/CloudNotes/CloudNotes/SceneDelegate.swift
+++ b/CloudNotes/CloudNotes/SceneDelegate.swift
@@ -17,6 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 switch authResult {
                 case .success(let token):
                     print("Success! User is logged into Dropbox with token: \(token)")
+                    DropBoxManager().uploadToDropBox()
                 case .cancel:
                     print("Authorization flow was manually canceled by user!")
                 case .error(_, let description):

--- a/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
@@ -35,7 +35,11 @@ struct DropBoxManager {
         fileNames.forEach { fileName in
             let fileURL = NSPersistentContainer.defaultDirectoryURL().appendingPathComponent(fileName)
             
-            dropBoxClient?.files.upload(path: "\(filePath)/\(fileName)", mode: .overwrite, autorename: true, clientModified: Date(), mute: false, propertyGroups: nil, strictConflict: false, input: fileURL)
+            guard let data = FileManager.default.contents(atPath: fileURL.path) else {
+                return
+            }
+            
+            dropBoxClient?.files.upload(path: "\(filePath)/\(fileName)", mode: .overwrite, input: data)
                 .response { response, error in
                     if let response = response {
                         print(response)

--- a/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
+++ b/CloudNotes/CloudNotes/Utility/DropBoxManager.swift
@@ -1,0 +1,69 @@
+import Foundation
+import SwiftyDropbox
+import CoreData
+
+struct DropBoxManager {
+    private let dropBoxClient = DropboxClientsManager.authorizedClient
+    
+    func presentSafariViewController(controller: UIViewController) {
+        let scopeRequest = ScopeRequest(scopeType: .user, scopes: [
+            "account_info.read",
+            "files.metadata.read",
+            "files.content.write",
+            "files.content.read"]
+                                        , includeGrantedScopes: false)
+        DropboxClientsManager.authorizeFromControllerV2(
+            UIApplication.shared,
+            controller: controller,
+            loadingStatusDelegate: nil,
+            openURL: { (url: URL) -> Void in UIApplication.shared.open(url, options: [:], completionHandler: nil) },
+            scopeRequest: scopeRequest
+        )
+    }
+    
+    func createFolderAtDropBox() {
+        dropBoxClient?.files.createFolderV2(path: "/test/path/in/Dropbox/account").response { response, error in
+            if let response = response {
+                print(response)
+            } else if let error = error {
+                print(error)
+            }
+        }
+    }
+    
+    func uploadToDropBox() {
+        let fileData = "testing data example".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        
+        let request = dropBoxClient?.files.upload(path: "/test/path/in/Dropbox/account", mode: .overwrite, autorename: true, clientModified: Date(), mute: false, propertyGroups: nil, strictConflict: false, input: fileData)
+            .response { response, error in
+                if let response = response {
+                    print(response)
+                } else if let error = error {
+                    print(error)
+                }
+            }
+            .progress { progressData in
+                print(progressData)
+            }
+    }
+    
+    func downloadFromDropBox() {
+        let fileURL = NSPersistentContainer.defaultDirectoryURL().appendingPathComponent("CloudNotes.sqlite")
+        
+        let destination: (URL, HTTPURLResponse) -> URL = { _, response in
+            return fileURL
+        }
+        
+        dropBoxClient?.files.download(path: "/test/path/in/Dropbox/CloudNotes.sqlite", overwrite: true, destination: destination)
+            .response(queue: .main) { response, error in
+                if let response = response {
+                    print(response)
+                } else if let error = error {
+                    print(error)
+                }
+            }
+            .progress { progressData in
+                print(progressData)
+            }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,31 +1,52 @@
-# 동기화 메모장 📝
 
+# 동기화 메모장 프로젝트
 
 ## 목차
-- [STEP1: 메모 리스트 및 내용 화면의 UI 구현](#STEP1:-메모-리스트-및-내용-화면의-UI-구현)
+- [STEP1 : 모델/네트워킹 타입 구현](##STEP1-메모-리스트-및-내용-화면의-UI-구현)
     + [키워드](#1-1-키워드)
     + [구현 내용](#1-2-구현-내용)
     + [고민한 점](#1-3-고민한-점)
 
+- [STEP2 : CoreData DB 구현](##STEP2-CoreData-DB-구현)
+    + [키워드](#2-1-키워드)
+    + [구현 내용](#2-2-구현-내용)
+    + [고민한 점](#2-3-고민한-점)
+
+- [STEP3 : 클라우드 연동](##STEP3-클라우드-연동)
+    + [키워드](#3-1-키워드)
+    + [구현 내용](#3-2-구현-내용)
+    + [고민한 점](#3-3-고민한-점)
+
+- [STEP4 : 추가 기능 구현](##STEP4-추가-기능-구현)
+    + [키워드](#4-1-키워드)
+    + [구현 내용](#4-2-구현-내용)
+    + [고민한 점](#4-3-고민한-점)
 
 ## 프로젝트 소개
-(프로젝트 완료 후 영상 추가 예정)
 
-## STEP1: 메모 리스트 및 내용 화면의 UI 구현
+|**메모 추가**|![](https://i.imgur.com/8NgYdVX.gif)|
+|:--:|:--:|
+|**메모 삭제**|![](https://i.imgur.com/YNz6R4t.gif)|
+|**메모 업데이트**|![](https://i.imgur.com/U3rk1Gh.gif)|
+|**CoreData**|![](https://i.imgur.com/ZjdfTg5.gif)|
+|**DropBox 연동**|![](https://i.imgur.com/qTF2Var.gif)|
+|**Dark Mode**|![](https://i.imgur.com/bjZaHnm.gif)|
+|**접근성**|![](https://i.imgur.com/l3M8FTE.gif)|
+|**메모 검색**|![](https://i.imgur.com/EkSJAyx.gif)|
 
+## STEP1 메모 리스트 및 내용 화면의 UI 구현
 ### 1-1 키워드
 - iPad, UISplitViewController
 - Dependency Injection
 - ARC, Weak References
 - Delegate Pattern
 - JSON, Decoding
-- DarkMode
 - DateFormatter
 - ContentOffset/ContentInset
 - Dynamic type
 - keyboardWillShowNotification
 - Swift Lint, Cocoa Pod
----
+
 ### 1-2 구현 내용
 - iPad 전용 메모 앱을 구현했습니다.
 - SplitView의 MasterView는 TableViewController, DetailView는 ViewController를 통해 구현하여 각각 메모의 목록 및 내용을 나타냈습니다. 이때 JSON 파일의 샘플 데이터를 통해 메모를 표시했습니다.
@@ -41,10 +62,12 @@
     - DetailViewController 클래스 : `SplitView`의 DetailView. delegate 프로토콜을 채택
 - 기타
     - SceneDelegate : Interface Buider 없이 코드로 UI를 구현하기 위해 스토리보드 삭제, MainSplitViewController 인스턴스 생성
----
+
 ### 1-3 고민한 점
 #### 1. delegate 패턴
-SplitView의 ChildView인 MasterTableViewController 및 DetailViewController 간의 의존성을 낮추기 위해 delegate 패턴을 사용했습니다. MasterView가 MemoSelectionDelegate 프로토콜 타입의 delegate를 가지고, DetailView가 MemoSelectionDelegate 프로토콜을 채택하도록 했습니다.
+SplitView의 ChildView인 MasterTableViewController 및 DetailViewController 간의 의존성을 낮추기 위해 delegate 패턴을 사용했습니다.
+
+MasterView가 MemoSelectionDelegate 프로토콜 타입의 delegate를 가지고, DetailView가 MemoSelectionDelegate 프로토콜을 채택하도록 했습니다.
 
 #### 2. 의존성 주입
 
@@ -95,4 +118,200 @@ JSON 파일을 파싱한 데이터를 tableView에서도 사용을 하고, table
 처음 생각한 방법은 Factory을 생성하는 것이었는데, 이는 DetailViewController를 생성하는 Factory이기 때문에 특정 셀이 클릭될 때마다 뷰컨트롤러가 새로이 생성되는 큰 문제점이 있을 것 같아 진행하지 않았습니다.
 
 그래서 결과적으로 방법-1의 `showDetailViewController` 메서드를 활용하여 하나의 뷰컨트롤러의 인스턴스를 미리 생성한 뒤 뷰에 올려진 텍스트뷰의 텍스트를 업데이트 해주는 방법으로 구현하였습니다.
+
+
+## STEP2 CoreData DB 구현
+### 2-1 키워드
+- CoreData CRUD
+- SwipeActionConfiguration
+- UIPopoverPresentationController
+- ActionSheet/Alert
+- UIAcitivityView
+- NSMutableAttributedString
+
+### 2-2 구현 내용
+- 싱글톤 CoreDataManager을 통해 CoreData CRUD 기능을 구현했습니다. 사용자가 수정한 메모를 실시간으로 CoreData에 저장하고, 목록에 나타내도록 했습니다. 
+- 메모 우상단의 더보기 버튼과 Cell Swipe 버튼을 통해 메모 공유/삭제 기능을 구현했습니다.
+- TextView의 메모 내용 중 첫 줄은 Title이 되고, 줄바꿈 이후부터 Body가 되도록 구현했습니다.
+- (요구사항 외) 앱 테스트를 원활히 진행하고자 TableView 상단의 +버튼을 통해 새 메모를 추가하도록 임시 기능을 구현했습니다.
+
+#### 코드 구조
+- Model
+- View
+- Controller
+- 기타
+- CoreData
+
+### 2-3 고민한 점 
+#### 1. 범용성 있는 CoreDataManager
+메모 데이터를 담고 있는 memos 배열을 CoreData와 TableViewDataSource 중에 어디에 저장해야 할지에 대해 고민했습니다.
+
+CoreDataManager를 범용성 있는 Utility 기능으로 구현하고 싶었기 때문에 CoreData가 memos를 가지지 않도록 하는 게 적절하다고 판단했습니다. 
+
+따라서 TableViewDataSource가 가지도록 했습니다. 또한 CoreDataManager의 fetch/delete 메서드 등도 확장성을 고려하여 제네릭 타입으로 생성했습니다.
+
+#### 2. MasterTableViewController 및 DetailViewController의 관계
+DetailView에서 받은 사용자 입력값을 어떻게 TableView List에 반영할지에 대해 고민했습니다.
+
+SplitViewController에 담겨있는 Master 및 Detail View의 의존성을 낮추기 위해 서로 모르도록 했습니다. 따라서 사용자가 DetailView에서 텍스트를 입력하거나, 메모를 삭제할 때 NofiticationCenter를 사용하여 MasterView에게 알려주도록 했습니다.
+
+그런데 기능을 추가하다보니 프로젝트 특성상 두 View의 연관성이 높을 수 밖에 없는 상황이라 서로 모르도록 한 것이 맞는 방향인지 의문이 들었습니다.
+
+#### 3. 사용자 입력값을 TableView에 반영하기
+사용자가 TextView에 입력한 내용을 TableView의 List에도 즉시 반영하기 위해 TextViewDelegate의 `shouldChangeTextIn` 메서드를 활용했습니다.
+
+하지만 확인해보니 사용자 입력값이 1개 문자씩 delay되어 반영되는 문제가 발생하여 `textViewDidChange` 메서드를 활용하도록 변경했습니다.
+
+#### 4. 메모의 첫 번째 줄은 제목으로, 그 다음 줄부터 본문으로 구분
+`shouldChangeTextIn` 메서드에서 `\n`으로 구분하여 TextView의 첫번째 줄은 Title로, 그 이외에는 Body로 설정해주어 CoreData에 저장했습니다.
+
+```swift 
+extension DetailViewController: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1)]
+        let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body)]
+
+        let text = textView.text as NSString
+        let titleRange = text.range(of: "\n")  // titleRange : 줄바꿈이 처음 나올 때까지의 range
+
+        if titleRange.location >= range.location {  // range.location : 현재 입력한 텍스트 (range 매개변수)의 location 
+            self.textView.typingAttributes = titleAttributes
+        } else {
+            self.textView.typingAttributes = bodyAttributes
+        }
+
+        return true
+    }
+}
+```
+이때 TextView에서 Title 및 Body를 구분하여 효과를 적용하기 위해 `NSMutableAttributedString`을 사용했습니다.
+
+```swift 
+private func updateTextView() {
+    let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1),
+                           NSAttributedString.Key.foregroundColor: UIColor.label]
+    let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
+                          NSAttributedString.Key.foregroundColor: UIColor.label]
+
+    let totalAttributedText = NSMutableAttributedString()
+    let titleAttributedText = NSMutableAttributedString(string: memo?.title ?? "", attributes: titleAttributes)
+    let bodyAattributedText = NSMutableAttributedString(string: "\n\n\(memo?.body ?? "")", attributes: bodyAttributes)
+
+    totalAttributedText.append(titleAttributedText)
+    totalAttributedText.append(bodyAattributedText)
+
+    textView.attributedText = totalAttributedText
+}
+```
+
+## STEP3 클라우드 연동
+### 3-1 키워드
+- Cloud, Data Synchronization
+- SwiftyDropbox, Cocoa Pod
+- SFSafariViewController
+
+### 3-2 구현 내용
+- 클라우드 (Dropbox) 연동을 위해 Cocoa Pod 및 SwiftyDropbox 라이브러리를 활용했습니다.
+- 코어데이터를 다른 기기와 동기화 할 수 있도록 DropBoxManager 타입 및 uploadToDropBox/downloadFromDropBox 메서드를 구현했습니다.
+- 클라우드 다운로드 
+    - 시점 : 앱 실행 시 초기화면에서 DropBox Safari ViewController를 present하고, DropBox 로그인이 성공했을 때 다운로드 하도록 구현하였습니다. (추후 로그인 실패 후 다시 로그인 시도를 할 수 있도록 버튼을 추가할 예정입니다.)
+    - 클라우드의 데이터를 다운로드하여 저장하는 위치는 PersistentContainer의 defaultDirectoryURL으로 설정했고, overwrite 모드로 구현하였습니다.
+- 클라우드 업로드 
+    - 시점 : 메모 추가/삭제할 때, 메모 업데이트할 때 (textViewDidEndEditing 메서드) 업로드를 하도록 구현하였습니다.
+    - 메모를 추가/삭제/수정할 때, 클라우드에 저장되어있는 데이터와 사용자의 CoreData에 저장되어 있는 데이터는 일치하므로 클라우드의 데이터를 다운받을 때 Overwrite를 하여도 문제가 없도록 구현하였습니다.
+
+#### 코드 구조
+- Utility
+    - DropBoxManager 클래스 : SafariViewController를 나타내어 사용자가 로그인할 수 있게 하고, CoreData의 데이터를 Dropbox에 업로드/다운로드함
+- 기타
+    - AppDelegate/info.plist : Dropbox AppKey, LSApplicationQueriesSchemes/URL types 정보를 등록함
+    
+### 3-3 고민한 점 
+#### 1. Download와 Upload의 시점
+
+클라우드를 이용한 메모이기에, 어떤 시점에서 클라우드를 통해 데이터를 주고 받을 지에 대한 고민을 해보았습니다.
+
+아무래도 모든 메모는 사용자가 직접 수정 또는 추가하기 전에 가장 최신버전의 메모에 기입을 해야한다고 생각을 해서, Download는 앱의 Scene Delegate에 구현을 해주었습니다.
+
+그리고 반대로, 사용자가 모든 메모의 작성이 끝나면 Upload가 되어야한다고 생각을 했기에, 실제 메모를 적을 수 있는 textView의 Delegate인 `textViewDidEndEditing` 에 구현을 해주었습니다.
+
+#### 2. DropBox 업로드/다운로드 오류 (***해결 후 업데이트 예정***)
+`uploadToDropBox` 메서드로 클라우드 업로드 (overwrite)를 할 때, 처음에는 문제가 없었는데 갑자기 DropBox의 3개 sqlite 파일 중 1개 (CloudNotes.sqlite)만 업데이트가 안되는 문제가 발생했습니다.
+
+CoreData가 저장된 `Application Support` 폴더 내부의 파일을 확인해봤는데, CoreData 파일은 정상적으로 업로드된 것을 확인했습니다. 그리고 업로드 response 출력문을 확인했을 때 3개 파일 모두 정상적으로 업로드된 것을 확인했습니다.
+
+![](https://i.imgur.com/TK1ZijW.png)
+
+왜 DropBox 폴더에서만 이러한 문제가 발생하는지 파악하고자 콘솔창의 에러문구를 모두 검색해봤지만 해결할 수 없었습니다.
+
+```
+// 다운로드 시 발생
+CoreData: error: -executeRequest: encountered exception = I/O error for database at /Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite.  SQLite error code:6922, 'disk I/O error' with userInfo = {
+    NSFilePath = "/Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite";
+    NSSQLiteErrorDomain = 6922;
+}
+
+[error] error: (6922) I/O error for database at /Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite.  SQLite error code:6922, 'disk I/O error'
+
+// 다운로드 및 업로드 시 발생
+[logging] BUG IN CLIENT OF libsqlite3.dylib: database integrity compromised by API violation: vnode unlinked while in use: /Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite-wal
+```
+
+
+## STEP4 추가 기능 구현
+### 4-1 키워드
+- Accessibility, Dynamic Type, Dark/Light Mode
+- UISearchController, UISearchResultTableViewController, SearchBar
+
+### 4-2 구현 내용
+- 메모 List 상단의 SearchBar를 통해 사용자가 메모를 검색하는 기능을 구현했습니다. 그리고 Dark/Light Mode에 모두 대응하도록 기능을 추가했습니다.
+
+#### 코드 구조
+- Controller
+    - SearchResultTableViewController 클래스 : SearchBar의 입력값을 전달받아 전체 메모 (memos 배열) 중 입력값을 포함하는 메모 (filteredMemos 배열)를 필터링하고, 검색 결과를 새로운 TableView 형태로 나타냄
+
+#### 1. SearchBar 추가
+메모 목록 상단에 SearchBar를 구현했습니다. 사용자의 입력값을 제목 또는 본문에 포함하고 있는 메모를 검색결과로 보여주도록 했습니다.
+
+이를 위해 Custom TableViewController인 `searchResultViewController` 타입을 추가했습니다. 그리고 `MaterTableViewController`에서 초기화했고, 생성자 주입을 통해 `MaterTableViewController`의 DataSource의 memos를 전달하도록 했습니다. 
+
+그리고 SearchBar에 텍스트를 입력할 때마다 호출되는 `updateSearchResults` 메서드 내부에서 `searchResultViewController`의 `searchMemo` 메서드를 호출하여 메모를 필터링했습니다.
+
+```swift=
+final class MasterTableViewController: UITableViewController {
+    private(set) var memoDataSource: MasterTableViewDataSourceProtocol?
+    weak var delegate: MemoSelectionDelegate?
+    lazy var searchResultViewController = SearchResultTableViewController(memos: memoDataSource?.retrieveMemos(), delegate: delegate)
+// ...
+}
+```
+
+처음에는 `searchResultViewController`와 `masterTableViewController`가 모두 동일한 memos 배열 데이터를 사용하므로 기존의 DataSource를 두 ViewController 모두 사용하도록 시도했습니다. 
+
+그런데 이 과정에서 타입캐스팅을 위해 DataSource가 ViewController를 알고 있어야하는 문제가 있었고, 의존성이 다시 높아진다고 판단하여 이 방법을 사용하지 않았습니다.
+
+
+#### 2. Dark Mode 미지원 레이블 추가적으로 지원
+테이블 뷰의 텍스트들은 DarkMode를 지원했지만, `DetailView`의 텍스트뷰의 텍스트는 지원이 안되고 있어 이를 수정해주었습니다.
+
+```swift
+// 수정 전
+let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1)]
+let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body)]
+
+// 수정 후
+let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1),
+                       NSAttributedString.Key.foregroundColor: UIColor.label]
+let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
+                      NSAttributedString.Key.foregroundColor: UIColor.label]
+```
+
+### 4-3 고민한 점 
+#### 1. 메모 추가 직후 검색 (***해결 후 업데이트 예정***)
+기존에 있던 메모를 검색하는 작업은 괜찮았지만 새 메모를 추가직후에 해당 메모는 검색이 안되는 버그가 있습니다.
+
+#### 2. 메모 검색 후 삭제
+특정 메모를 검색한 뒤 메모를 삭제하면 코어데이터나, 검색창을 끈 뒤의 테이블뷰에서는 정상적으로 삭제가 되는데 검색창을 띄운 상태에선 삭제가 되지 않는 버그가 있습니다.
+
+
 


### PR DESCRIPTION
안녕하세요 콘!! @protocorn93
애플사이다, Jiseong, Toni 입니다. 저희 Step3와 Step4 합쳐서 PR 보내드립니다.
비록 알 수 없는 오류들이 발생하긴 했지만..최대한 해결해보려고 노력했습니다.
언제나 정성어린 답변 감사드립니다.

## STEP3 구현내용 및 고민한 점
### 구현 내용
- 클라우드 (Dropbox) 연동을 위해 Cocoa Pod 및 SwiftyDropbox 라이브러리를 활용했습니다.
- 코어데이터를 다른 기기와 동기화 할 수 있도록 DropBoxManager 타입 및 uploadToDropBox/downloadFromDropBox 메서드를 구현했습니다. 
    - 클라우드 다운로드 시점 : 앱 실행 시 초기화면에서 DropBox Safari ViewController를 present하고, DropBox 로그인이 성공했을 때 다운로드 하도록 구현하였습니다. (추후 로그인 실패 후 다시 로그인 시도를 할 수 있도록 버튼을 추가할 예정입니다.)
    
    - 클라우드의 데이터를 다운로드하여 저장하는 위치는 PersistentContainer의 `defaultDirectoryURL`으로 설정했고, overwrite 모드로 구현하였습니다.

    - 클라우드 업로드 시점 : 메모 추가/삭제할 때, 메모 업데이트할 때 (`textViewDidEndEditing` 메서드) 업로드를 하도록 구현하였습니다. 

    - 메모를 추가/삭제/수정할 때 (사용자가 메모를 작성한 뒤) 클라우드에 저장되어있는 데이터와 사용자의 CoreData에 저장되어 있는 데이터는 일치하므로 클라우드의 데이터를 다운받을 때 Overwrite를 하여도 문제가 없도록 구현하였습니다.

## STEP4 구현내용 및 고민한 점
### SearchBar 추가
- 메모 목록 상단에 SearchBar를 구현했습니다. 사용자의 입력값을 제목 또는 본문에 포함하고 있는 메모를 검색결과로 보여주도록 했습니다.
- 이를 위해 `Custom TableViewController`인 `searchResultViewController` 타입을 추가했습니다. 그리고 MaterTableViewController에서 초기화했고, 생성자 주입을 통해 MaterTableViewController의 DataSource의 memos를 전달하도록 했습니다. 그리고 서치바에 텍스트를 입력할 때마다 호출되는 updateSearchResults 메서드 내부에서 searchResultViewController의 searchMemo 메서드를 호출하여 메모를 필터링했습니다.
```swift 
final class MasterTableViewController: UITableViewController {
    private(set) var memoDataSource: MasterTableViewDataSourceProtocol?
    weak var delegate: MemoSelectionDelegate?
    lazy var searchResultViewController = SearchResultTableViewController(memos: memoDataSource?.retrieveMemos(), delegate: delegate)
// ...
}
```

- 처음에는 searchResultViewController와 masterTableViewController가 모두 동일한 memos 배열 데이터를 사용하므로 기존의 DataSource를 두 ViewController 모두 사용하도록 시도했습니다. 그런데 이 과정에서 타입캐스팅을 위해 DataSource가 ViewController를 알고 있어야하는 문제가 있었고, 의존성이 다시 높아진다고 판단하여 이 방법을 사용하지 않았습니다.

### Dark Mode 미지원 레이블 추가적으로 지원

테이블 뷰의 텍스트들은 DarkMode를 지원했지만, DetailView의 텍스트뷰의 텍스트는 지원이 안되고 있어 이를 수정해주었습니다.

```swift
// 수정 전
let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1)]
let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body)]

// 수정 후
let titleAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title1),
                       NSAttributedString.Key.foregroundColor: UIColor.label]
let bodyAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
                      NSAttributedString.Key.foregroundColor: UIColor.label]
```


## 해결하지 못한 점
### 1. DropBox 업로드/다운로드 오류
`uploadToDropBox` 메서드로 클라우드 업로드 (overwrite)를 할 때, 처음에는 문제가 없었는데 갑자기 DropBox의 3개 sqlite 파일 중 1개 (CloudNotes.sqlite)만 업데이트가 안되는 문제가 발생했습니다.

CoreData가 저장된 `Application Support` 폴더 내부의 파일을 확인해봤는데, CoreData 파일은 정상적으로 업로드된 것을 확인했습니다. 그리고 업로드 response 출력문을 확인했을 때 3개 파일 모두 정상적으로 업로드된 것을 확인했습니다.

![](https://i.imgur.com/TK1ZijW.png)


왜 DropBox 폴더에서만 이러한 문제가 발생하는지 파악하고자 콘솔창의 에러문구를 모두 검색해봤지만 해결할 수 없었습니다.

```
// 다운로드 시 발생
CoreData: error: -executeRequest: encountered exception = I/O error for database at /Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite.  SQLite error code:6922, 'disk I/O error' with userInfo = {
    NSFilePath = "/Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite";
    NSSQLiteErrorDomain = 6922;
}

[error] error: (6922) I/O error for database at /Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite.  SQLite error code:6922, 'disk I/O error'

// 다운로드 및 업로드 시 발생
[logging] BUG IN CLIENT OF libsqlite3.dylib: database integrity compromised by API violation: vnode unlinked while in use: /Users/hyojuson/Library/Developer/CoreSimulator/Devices/05F35EA9-9E39-492C-8223-F54BBC92A49F/data/Containers/Data/Application/5D565A17-0D9F-4738-A637-D2A9DA49FFE9/Library/Application Support/CloudNotes.sqlite-wal
```

커밋을 되돌리거나, 조원 모두가 실행을 해봐도 같은 오류가 발생하였습니다.

### 2. 메모 추가 직후 검색

기존에 있던 메모를 검색하는 작업은 괜찮았지만 새 메모를 추가직후에 해당 메모는 검색이 안되는 버그가 있습니다.

### 3. 메모 검색 후 삭제

특정 메모를 검색한 뒤 메모를 삭제하면 코어데이터나, 검색창을 끈 뒤의 테이블뷰에서는 정상적으로 삭제가 되는데 검색창을 띄운 상태에선 삭제가 되지 않는 버그가 있습니다.


## 궁금한 점
### `Download`와 `Upload`의 시점
클라우드를 이용한 메모이기에, 어떤 시점에서 클라우드를 통해 데이터를 주고 받을 지에 대한 고민을 해보았습니다. 

아무래도 모든 메모는 사용자가 직접 수정 또는 추가하기 전에 가장 최신버전의 메모에 기입을 해야한다고 생각을 해서, `Download`는 앱의 `Scene Delegate`에 구현을 해주었습니다.

그리고 반대로, 사용자가 모든 메모의 작성이 끝나면 `Upload`가 되어야한다고 생각을 했기에, 실제 메모를 적을 수 있는 `textView`의 `Delegate`인 `textViewDidEndEditing 에 구현을 해주었습니다. 

이렇게 저희가 생각한 다운로드 및 업로드의 시점이 적절한지 여쭙고 싶습니다.
